### PR TITLE
Hot Draconium Ingot Fix

### DIFF
--- a/overrides/scripts/ContentTweaker.zs
+++ b/overrides/scripts/ContentTweaker.zs
@@ -427,7 +427,9 @@ hotdraconiumingot.rarity = "rare";
 hotdraconiumingot.maxStackSize = 16;
 
 hotdraconiumingot.onItemUpdate = function(itemStack, world, owner, slot, isSelected) {
-    owner.attackEntityFrom(<damageSource:heat>.setDamageBypassesArmor(), 3.0);
+    if (world.getWorldTime() % 20 == 0) {
+        owner.attackEntityFrom(<damageSource:heat>.setDamageBypassesArmor(), 3.0);
+    }
     return;
 };
 

--- a/overrides/scripts/ContentTweaker.zs
+++ b/overrides/scripts/ContentTweaker.zs
@@ -424,7 +424,13 @@ ultimate_generator.register();
 
 var hotdraconiumingot = VanillaFactory.createItem("hotdraconiumingot");
 hotdraconiumingot.rarity = "rare";
-hotdraconiumingot.maxStackSize = 64;
+hotdraconiumingot.maxStackSize = 16;
+
+hotdraconiumingot.onItemUpdate = function(itemStack, world, owner, slot, isSelected) {
+    owner.attackEntityFrom(<damageSource:heat>.setDamageBypassesArmor(), 3.0);
+    return;
+};
+
 hotdraconiumingot.register();
 
 


### PR DESCRIPTION
Implement burn damage from Hot Draconium Ingots and reduce stack size to 16.

May need testing:

With the fix installed, die. This caused invulnerability for me until server restart. This may or may not have been caused by this change.