### PR TITLE
Fixed thorium duping via fluid extractor

### DIFF
--- a/overrides/scripts/Nuclearcraft.zs
+++ b/overrides/scripts/Nuclearcraft.zs
@@ -4,16 +4,6 @@ import crafttweaker.oredict.IOreDictEntry;
 import mods.contenttweaker.Fluid;
 import mods.gregtech.recipe.RecipeMap;
 
-val fluid_extractor = RecipeMap.getByName("fluid_extractor");
-val macerator = RecipeMap.getByName("macerator");
-val mixer = RecipeMap.getByName("mixer");
-val alloy = RecipeMap.getByName("alloy_smelter");
-val thermal_sep = RecipeMap.getByName("thermal_centrifuge");
-val compressor = RecipeMap.getByName("compressor");
-val canner = RecipeMap.getByName("canner");
-val fluid_canner = RecipeMap.getByName("fluid_canner");
-val reactor = RecipeMap.getByName("chemical_reactor");
-
 /*
 [[<>, <>, <>, <>, <>, <>],
 [<>, <>, <>, <>, <>, <>],

--- a/overrides/scripts/Nuclearcraft.zs
+++ b/overrides/scripts/Nuclearcraft.zs
@@ -2,9 +2,9 @@ import crafttweaker.item.IItemStack;
 import crafttweaker.item.IIngredient;
 import crafttweaker.oredict.IOreDictEntry;
 import mods.contenttweaker.Fluid;
-
 import mods.gregtech.recipe.RecipeMap;
 
+val fluid_extractor = RecipeMap.getByName("fluid_extractor");
 val macerator = RecipeMap.getByName("macerator");
 val mixer = RecipeMap.getByName("mixer");
 val alloy = RecipeMap.getByName("alloy_smelter");
@@ -177,6 +177,18 @@ recipes.addShaped(<nuclearcraft:part:5>, [
 
 thermal_sep.recipeBuilder().inputs([<gregtech:meta_item_1:2076>]).outputs(<nuclearcraft:uranium:4>).EUt(48).duration(3200).buildAndRegister();
 thermal_sep.recipeBuilder().inputs([<gregtech:meta_item_1:10076>]).outputs(<nuclearcraft:uranium:4>).EUt(48).duration(3200).buildAndRegister();
+
+fluidextractor.findRecipe(32, [<nuclearcraft:thorium:4>], null).remove();
+fluidextractor.findRecipe(32, [<nuclearcraft:thorium:0>], null).remove();
+fluidextractor.findRecipe(32, [<nuclearcraft:thorium:2>], null).remove();
+fluidextractor.findRecipe(32, [<nuclearcraft:thorium:6>], null).remove();
+
+mixer.recipeBuilder()
+	.inputs(<ore:nuggetThorium230> * 1, <ore:nuggetThorium232> * 9)
+	.outputs(<gregtech:meta_item_1:2069)
+	.duration(160)
+    .EUt(32)
+    .buildAndRegister();
 
 
 


### PR DESCRIPTION
The way nuclearcraft isotopes work is a natural ingot (144mb) is split into a clump (144mb) and small clump (16mb), both oredicted as a ingot and nugget. Gregtech sees these oredicts, and decides to add recipes in the fluid extractor for thorium, even though these aren't supposed to be recombined into natural thorium. The script removes these recipes, and adds a new one in the mixer to recombine the correct isotopes into thorium dust.

As per usual in the modded minecraft world, law of conservation of mass is a joke.

- fixed #228