### PR TITLE
Blacklist certain blocks to prevent Exchanger Gadget mining

### DIFF
--- a/overrides/config/Building Gadgets.cfg
+++ b/overrides/config/Building Gadgets.cfg
@@ -46,6 +46,9 @@ general {
         S:"Blacklisted Blocks" <
             minecraft:.*_door.*
             minecraft:piston_head
+            minecraft:reeds
+            *:*torch*
+            *:*flower*
          >
     }
 


### PR DESCRIPTION
This is by no means a full list of blocks that can be used like that, but it will make it just a bit harder.