### PR TITLE
Change the amount of Molten Tank produced by a Heart

### DIFF
--- a/overrides/scripts/ExtendedCrafting.zs
+++ b/overrides/scripts/ExtendedCrafting.zs
@@ -513,7 +513,7 @@ mods.extendedcrafting.TableCrafting.addShaped(<storagedrawers:upgrade_creative:1
 [<storagedrawers:upgrade_creative>, 	<avaritia:resource:6>, 				<avaritia:resource:6>, 				<avaritia:resource:6>, 						<avaritia:resource:6>, 						<avaritia:resource:6>, 						<avaritia:resource:6>, 					<avaritia:resource:6>, 							<storagedrawers:upgrade_creative>]]);
 
 solidifier.recipeBuilder().fluidInputs([<liquid:moltencreativeportabletank> * 144]).notConsumable(<contenttweaker:creativeportabletankmold>).outputs(creativetank).duration(500).EUt(100000).buildAndRegister();
-fluid_extractor.recipeBuilder().inputs([<contenttweaker:heartofauniverse>]).fluidOutputs([<liquid:moltencreativeportabletank>*288]).duration(500).EUt(100000).buildAndRegister();
+fluid_extractor.recipeBuilder().inputs([<contenttweaker:heartofauniverse>]).fluidOutputs([<liquid:moltencreativeportabletank>*145]).duration(500).EUt(100000).buildAndRegister();
 
 
 ////////////////////////// Creative Items ///////////////////////


### PR DESCRIPTION
This changes the amount of Molten Creative Portable Tank a Heart produces from 288mb to 145mb, which prevents players from accidentally making two tanks by leaving exacty 1mb of fluid in the input, to configure the freshly crafted Creative Portable Tank with.

Should not break any current setups.