### PR TITLE
Add dirt recipe

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -30,6 +30,8 @@ recipes.addShaped(<gregtech:meta_item_2:32570>, [
 	[<ore:treeSapling>,<ore:treeSapling>,<ore:treeSapling>]]);
 furnace.addRecipe(<minecraft:slime_ball> * 2, <gregtech:meta_item_2:32570>, 0.0);
 
+//Removes the unobtainable dirt recipe
+recipes.removeByRecipeName("thermalfoundation:block_dirt");
 
 //Add in a new dirt recipe
 recipes.addShaped(<minecraft:dirt> * 16, [

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -30,6 +30,13 @@ recipes.addShaped(<gregtech:meta_item_2:32570>, [
 	[<ore:treeSapling>,<ore:treeSapling>,<ore:treeSapling>]]);
 furnace.addRecipe(<minecraft:slime_ball> * 2, <gregtech:meta_item_2:32570>, 0.0);
 
+
+//Add in a new dirt recipe
+recipes.addShaped(<minecraft:dirt> * 16, [
+	[<ore:treeSapling>,<ore:treeSapling>,null],
+	[<minecraft:clay>,<deepmoblearning:living_matter_overworldian>,null],
+	[null,null,null]]);
+
 //Mining Hammers
 <thermalfoundation:tool.hammer_stone>.displayName = "Stone Mining Hammer";
 <thermalfoundation:tool.hammer_stone>.addTooltip(format.red("Do not break GT multiblocks with a hammer, pieces will be deleted!"));

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -30,14 +30,6 @@ recipes.addShaped(<gregtech:meta_item_2:32570>, [
 	[<ore:treeSapling>,<ore:treeSapling>,<ore:treeSapling>]]);
 furnace.addRecipe(<minecraft:slime_ball> * 2, <gregtech:meta_item_2:32570>, 0.0);
 
-//Removes the unobtainable dirt recipe
-recipes.removeByRecipeName("thermalfoundation:block_dirt");
-
-//Add in a new dirt recipe
-recipes.addShaped(<minecraft:dirt> * 16, [
-	[<ore:treeSapling>,<ore:treeSapling>,null],
-	[<minecraft:clay>,<deepmoblearning:living_matter_overworldian>,null],
-	[null,null,null]]);
 
 //Mining Hammers
 <thermalfoundation:tool.hammer_stone>.displayName = "Stone Mining Hammer";

--- a/overrides/scripts/SolarFlux.zs
+++ b/overrides/scripts/SolarFlux.zs
@@ -159,9 +159,8 @@ recipes.removeByRecipeName("thermalfoundation:block_dirt");
 
 //Add in a new dirt recipe
 recipes.addShapeless(<minecraft:dirt> * 16, [
-	[<ore:treeSapling>,<ore:treeSapling>,null],
-	[<minecraft:clay>,<deepmoblearning:living_matter_overworldian>,null],
-	[null,null,null]]);
+	<ore:treeSapling>,<ore:treeSapling>,
+	<minecraft:clay>,<deepmoblearning:living_matter_overworldian>]);
 
 
 

--- a/overrides/scripts/SolarFlux.zs
+++ b/overrides/scripts/SolarFlux.zs
@@ -154,6 +154,15 @@ alloy.recipeBuilder().inputs([<minecraft:slime>,<minecraft:redstone>]).outputs([
 
 recipes.addShapeless(<minecraft:skull:1>, [<minecraft:skull>,<minecraft:skull>,<minecraft:skull>,<deepmoblearning:living_matter_hellish>]);
 
+//Removes the unobtainable dirt recipe
+recipes.removeByRecipeName("thermalfoundation:block_dirt");
+
+//Add in a new dirt recipe
+recipes.addShapeless(<minecraft:dirt> * 16, [
+	[<ore:treeSapling>,<ore:treeSapling>,null],
+	[<minecraft:clay>,<deepmoblearning:living_matter_overworldian>,null],
+	[null,null,null]]);
+
 
 
 recipes.addShaped(<enderio:item_soul_vial:1>.withTag({entityId: "minecraft:zombie"}), [


### PR DESCRIPTION
Adds a dirt recipes, fixes #197 
Let me know if you want me to move the recipe to a different file, I just stuck in in the Earlygame script because dirt is an early game item. I also removed the non-functional dirt recipe, with the slag and the pulped biomass. I considered using a Plant Ball instead of the clay, but that gave the possibility for duping dirt via the centrifuge, which is not that big of a problem, but I figured I would avoid it anyway.