### PR TITLE
Add additional Enderio Glasses

### DIFF
--- a/overrides/scripts/EnderIO.zs
+++ b/overrides/scripts/EnderIO.zs
@@ -123,3 +123,13 @@ recipes.addShapeless(
     , [<enderio:item_dark_steel_upgrade>, <solarflux:solar_panel_4>]
 );
 
+//Extra Enderio Glasses
+
+//Enlightened Quite Clear Glass
+alloy.recipeBuilder().inputs([<enderio:block_fused_glass:0>, <minecraft:glowstone>]).outputs([<enderio:block_enlightened_fused_glass:0>]).duration(160).EUt(16).buildAndRegister();	
+
+//Enlightened Fused Quartz
+alloy.recipeBuilder().inputs([<enderio:block_fused_quartz:0>, <minecraft:glowstone>]).outputs([<enderio:block_enlightened_fused_quartz:0>]).duration(160).EUt(16).buildAndRegister();
+
+//Dark Fused Quarz
+alloy.recipeBuilder().inputs([<actuallyadditions:item_misc:5>, <enderio:block_fused_glass:*>]).outputs([<enderio:block_dark_fused_quartz:0>]).duration(200).EUt(32).buildAndRegister();	

--- a/overrides/scripts/EnderIO.zs
+++ b/overrides/scripts/EnderIO.zs
@@ -123,6 +123,7 @@ recipes.addShapeless(
     , [<enderio:item_dark_steel_upgrade>, <solarflux:solar_panel_4>]
 );
 
+
 //Extra Enderio Glasses
 
 //Enlightened Quite Clear Glass

--- a/overrides/scripts/Midgame.zs
+++ b/overrides/scripts/Midgame.zs
@@ -18,7 +18,6 @@ val centrifuge = RecipeMap.getByName("centrifuge");
 val assembler = RecipeMap.getByName("assembler");
 val saw = RecipeMap.getByName("cutting_saw");
 val extruder = RecipeMap.getByName("extruder");
-val alloy = RecipeMap.getByName("alloy_smelter");
 
 recipes.addShapeless(<appliedenergistics2:network_tool>, [<ore:itemIlluminatedPanel>, <actuallyadditions:item_laser_wrench>]);
 

--- a/overrides/scripts/Midgame.zs
+++ b/overrides/scripts/Midgame.zs
@@ -355,16 +355,7 @@ recipes.addShaped(<enderio:item_material:41>, [
 	[<enderio:item_alloy_ingot:7>,<ore:circuitGood>,<enderio:item_alloy_ingot:7>], 
 	[<gregtech:meta_item_2:32440>,<ore:blockRedAlloy>,<gregtech:meta_item_2:32440>]]);
 
-//Extra Enderio Glasses
-
-//Enlightened Quite Clear Glass
-alloy.recipeBuilder().inputs([<enderio:block_fused_glass:0>, <minecraft:glowstone>]).outputs([<enderio:block_enlightened_fused_glass:0>]).duration(160).EUt(16).buildAndRegister();	
-
-//Enlightened Fused Quartz
-alloy.recipeBuilder().inputs([<enderio:block_fused_quartz:0>, <minecraft:glowstone>]).outputs([<enderio:block_enlightened_fused_quartz:0>]).duration(160).EUt(16).buildAndRegister();
-
-//Dark Fused Quarz
-alloy.recipeBuilder().inputs([<actuallyadditions:item_misc:5>, <enderio:block_fused_glass:*>]).outputs([<enderio:block_dark_fused_quartz:0>]).duration(200).EUt(32).buildAndRegister();		
+	
 
 
 

--- a/overrides/scripts/Midgame.zs
+++ b/overrides/scripts/Midgame.zs
@@ -18,6 +18,7 @@ val centrifuge = RecipeMap.getByName("centrifuge");
 val assembler = RecipeMap.getByName("assembler");
 val saw = RecipeMap.getByName("cutting_saw");
 val extruder = RecipeMap.getByName("extruder");
+val alloy = RecipeMap.getByName("alloy_smelter");
 
 recipes.addShapeless(<appliedenergistics2:network_tool>, [<ore:itemIlluminatedPanel>, <actuallyadditions:item_laser_wrench>]);
 
@@ -354,6 +355,17 @@ recipes.addShaped(<enderio:item_material:41>, [
 	[<enderio:item_alloy_ingot:7>,<minecraft:skull:2>,<enderio:item_alloy_ingot:7>],
 	[<enderio:item_alloy_ingot:7>,<ore:circuitGood>,<enderio:item_alloy_ingot:7>], 
 	[<gregtech:meta_item_2:32440>,<ore:blockRedAlloy>,<gregtech:meta_item_2:32440>]]);
+
+//Extra Enderio Glasses
+
+//Enlightened Quite Clear Glass
+alloy.recipeBuilder().inputs([<enderio:block_fused_glass:0>, <minecraft:glowstone>]).outputs([<enderio:block_enlightened_fused_glass:0>]).duration(160).EUt(16).buildAndRegister();	
+
+//Enlightened Fused Quartz
+alloy.recipeBuilder().inputs([<enderio:block_fused_quartz:0>, <minecraft:glowstone>]).outputs([<enderio:block_enlightened_fused_quartz:0>]).duration(160).EUt(16).buildAndRegister();
+
+//Dark Fused Quarz
+alloy.recipeBuilder().inputs([<actuallyadditions:item_misc:5>, <enderio:block_fused_glass:*>]).outputs([<enderio:block_dark_fused_quartz:0>]).duration(200).EUt(32).buildAndRegister();		
 
 
 


### PR DESCRIPTION
Closes #216 
The two enlightened variants simply combine the glass with a block of glowstone, and are available at LV since the original glass blocks are available then as well. The Dark glass variant combines black quartz with quite clear glass to make it a little bit harder, as it prevents light from going through. This variant requires either early exploration to find some black quartz ore, or waiting until MV to be able to make black quartz dust.