### PR TITLE
Allow GTCE aluminum to be chiselable

### DIFF
--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -974,7 +974,7 @@ for oreDictEntry, items in miscDisabled {
 <ore:oreEmerald>.add(<minecraft:emerald_ore>);
 <ore:oreNetherQuartz>.add(<minecraft:quartz_ore>);
 
-
+<ore:blockAluminum>.add(<gregtech:compressed_0:0>);
 
 ////////////////////////////////
 //			Removals          //


### PR DESCRIPTION
Closes #200 
Simply adds the GTCE aluminum block to the chisel oredict for aluminum blocks. This results in having the GTCE block in both aluminum oredicts, but it should be fine.