### PR TITLE
Should fix MM casings being craftable by hand

### DIFF
--- a/overrides/scripts/Endgame.zs
+++ b/overrides/scripts/Endgame.zs
@@ -203,7 +203,7 @@ recipes.remove(<gregtech:machine_casing:6>);
 recipes.remove(<gregtech:machine:506>);
 recipes.addShaped(<gregtech:machine_casing:6>, [
 	[<ore:plateLumium>, <ore:plateLumium>, <ore:plateLumium>], 
-	[<ore:plateLumium>, <ore:craftingToolWrench>, <ore:plateLumium>], 
+	[<ore:plateLumium>, <gregtech:meta_tool:8>, <ore:plateLumium>], 
 	[<ore:plateLumium>, <ore:plateLumium>, <ore:plateLumium>]]);
 recipes.addShaped(<gregtech:machine:506>, [
 	[<ore:platePlastic>, <ore:plateLumium>, <ore:platePlastic>], 

--- a/overrides/scripts/Microverse.zs
+++ b/overrides/scripts/Microverse.zs
@@ -94,7 +94,7 @@ recipes.addShaped(<modularmachinery:blockenergyoutputhatch:7>, [[null, <modularm
 
 //Casing
 recipes.remove(<modularmachinery:blockcasing>);
-recipes.addShaped(<modularmachinery:blockcasing> * 2, [[<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>],[<modularmachinery:itemmodularium>,<ore:craftingToolWrench>,<modularmachinery:itemmodularium>],[<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>]]);
+recipes.addShaped(<modularmachinery:blockcasing> * 2, [[<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>],[<modularmachinery:itemmodularium>,<gregtech:meta_tool:8>,<modularmachinery:itemmodularium>],[<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>]]);
 assembler.recipeBuilder().inputs([<modularmachinery:itemmodularium> * 4]).outputs([<modularmachinery:blockcasing>]).duration(200).EUt(30).buildAndRegister();
 
 // Machine Vent


### PR DESCRIPTION
This should close #175 . I tested it by hand crafting, where it worked with multiple wrenches, not just the Darmstadtium one. It also worked when the wrenches were damaged. I also tested the pattern with the wrench in AE, as it was mentioned that it would not work there, and the pattern worked fine (Make sure ore-dict substitutions is enabled for anyone who uses this pattern instead of the assembler). It should also fix a similar case with the LuV machine casing, where it was only craftable with the Darmstadtium wrench.