### PR TITLE
🦀 Remove phosphorus pentoxide 🦀

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -349,8 +349,16 @@ reactor.findRecipe(480, [null], [<liquid:chloramine> * 1000, <liquid:dimethylami
 reactor.findRecipe(480, [null], [<liquid:methanol> * 2000, <liquid:ammonia> * 1000, <liquid:hypochlorous_acid> * 1000]).remove();
 reactor.recipeBuilder().fluidInputs(<liquid:chloramine> * 1000, <liquid:dimethylamine> * 1000).fluidOutputs(<liquid:dimethylhidrazine> * 1000,<liquid:diluted_hydrochloric_acid> * 1000).EUt(120).duration(960).buildAndRegister();
 
+//Remove phosphorus pentoxide, not used anywhere aside from duping phosphorus
+reactor.findRecipe(30, [<gregtech:meta_item_1:2466>], [<liquid:water> * 6000]).remove();
+reactor.findRecipe(30, [<gregtech:meta_item_1:2050> * 4], [<liquid:oxygen> * 10000]).remove();
+electrolyzer.findRecipe(30, [<gregtech:meta_item_1:2466> * 14], null).remove();
 
-
+mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:466>);
+mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:1466>);
+mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:2466>);
+mods.jei.JEI.removeAndHide(<gregtech:compressed_16:13>);
+mods.jei.JEI.removeAndHide(<appliedenergistics2:facade>.withTag({damage: 13, item: "gregtech:compressed_16"}));
 
 //Lava Factory
 recipes.remove(<actuallyadditions:block_misc:7>);


### PR DESCRIPTION
Not used anywhere aside from duping phosphorus
![BlondCluelessHyrax-max-1mb](https://user-images.githubusercontent.com/22255622/72958493-896e1500-3dfb-11ea-96dc-7c6076dc0783.gif)
