### PR TITLE
Switch basic microminer guidance systems to use MV sensors instead of LV

### DIFF
--- a/overrides/scripts/Microverse.zs
+++ b/overrides/scripts/Microverse.zs
@@ -112,7 +112,7 @@ recipes.addShaped(<contenttweaker:tieroneship>, [
 
 //Tier 1 Guidance
 recipes.addShaped(<contenttweaker:t1guidance>,
-	[[<gregtech:meta_item_1:32690>, <contenttweaker:steelplating>, <gregtech:meta_item_1:32690>],
+	[[<gregtech:meta_item_1:32691>, <contenttweaker:steelplating>, <gregtech:meta_item_1:32691>],
 	[<contenttweaker:steelplating>, <ore:circuitGood>, <contenttweaker:steelplating>],
 	[<ore:circuitGood>,<ore:circuitGood>,<ore:circuitGood>]]);
 


### PR DESCRIPTION
As per a small discussion in the discord, there was a realisation that Quartzite is pretty much only used for the LV Sensors in Basic Guidance Systems. There's currently no way of getting Quartzite that doesn't require some player intervention, making requesting a huge amount of low tier microminers for the Dilithium late on potentially a minor pain.

A quick solution is to simply switch the guidance system to use MV Sensors. 

Personally, when I first got to making the T1 Microminer I remember thinking "wtf LV really" as I'd long outgrown any need for LV components and my factory wasn't setup to produce any of it. So this change would help the progression be a little smoother too IMO.