### PR TITLE
Electric furnace buff

### DIFF
--- a/overrides/scripts/ElectricFurnaceFix.zs
+++ b/overrides/scripts/ElectricFurnaceFix.zs
@@ -1,3 +1,4 @@
+#priority -10
 import mods.gregtech.recipe.RecipeMap;
 import crafttweaker.recipes.IFurnaceRecipe;
 

--- a/overrides/scripts/ElectricFurnaceFix.zs
+++ b/overrides/scripts/ElectricFurnaceFix.zs
@@ -1,0 +1,16 @@
+import mods.gregtech.recipe.RecipeMap;
+import crafttweaker.recipes.IFurnaceRecipe;
+
+var furnaceMap = RecipeMap.getByName("furnace") as RecipeMap;
+//Register a custom electric furnace recipe for every vanilla furnace recipe
+for i, rec in furnace.all {
+	if(i%100 == 0) {
+		print("Modifiying furnace recipe number "~i);
+	}
+	furnaceMap.recipeBuilder()
+		.inputs(rec.input)
+		.outputs(rec.output)
+		.duration(64)
+		.EUt(30)
+		.buildAndRegister();
+}


### PR DESCRIPTION
Modified the smelting recipes from the default of 128t at 4EU/t to 64t at 30EU/t. At LV there is no change in speed, but the recipe overclocks at 2.8x now. This means it reaches a duration of 3t at EV and doesn't overclock further.
Subject to criticism - furnaces shouldn't replace multismelters, so maybe it's too much of a buff.
As a side effect, all electric furnace recipes (2003 of them) are now shown in JEI.