### PR TITLE
Disable double ingots and curved plates

### DIFF
--- a/overrides/config/gtadditions.cfg
+++ b/overrides/config/gtadditions.cfg
@@ -28,10 +28,10 @@ general {
         B:"Should Electrodes be registered?"=false
 
         # Set this to false to disable curved plates
-        B:"Should curved plates be registered?"=true
+        B:"Should curved plates be registered?"=false
 
         # Set this to false to disable double ingots
-        B:"Should double ingots be registered?"=true
+        B:"Should double ingots be registered?"=false
 
         # Set this to false to disable rounds
         B:"Should rounds be registered?"=true

--- a/overrides/scripts/JEICleanup.zs
+++ b/overrides/scripts/JEICleanup.zs
@@ -1,0 +1,103 @@
+#priority -9998
+
+import crafttweaker.mods.IMod;
+import crafttweaker.game.IGame;
+import crafttweaker.item.IItemDefinition;
+import crafttweaker.item.IItemStack;
+import crafttweaker.item.IIngredient;
+import crafttweaker.liquid.ILiquidDefinition;
+import crafttweaker.liquid.ILiquidStack;
+import crafttweaker.oredict.IOreDict;
+import crafttweaker.oredict.IOreDictEntry;
+
+/*
+    MetaIDs of SoG's curved plates and double-ingots that aren't gone from JEI
+    even with the config options set to not use them...
+*/
+val curvedPlatesDoubleIngots as int[] = [1, 2, 3, 7, 16, 17, 18, 21, 22, 25, 26,
+ 32, 33, 35, 36, 39, 42, 43, 44, 45, 47, 49, 51, 52, 53, 54, 55, 56, 58, 59, 60,
+ 61, 62, 63, 64, 66, 67, 68, 69, 70, 71, 72, 74, 75, 76, 77, 78, 79, 87, 91, 94,
+ 95, 109, 112, 126, 127, 129, 133, 134, 135, 140, 141, 142, 144, 145, 152, 180,
+ 183, 184, 189, 192, 195, 197, 200, 204, 205, 207, 227, 228, 229, 230, 231, 232,
+ 233, 234, 235, 237, 238, 297, 298, 299, 300, 301, 302, 303, 304, 307, 308, 309,
+ 310, 311, 312, 353, 391, 395, 398, 410, 411, 421, 424, 470, 700, 701, 702, 703,
+ 704, 705, 712, 713, 714, 965, 972, 1001, 1002, 1003, 1007, 1016, 1017, 1018,
+ 1021, 1022, 1025, 1026, 1032, 1033, 1035, 1036, 1039, 1042, 1043, 1044, 1045,
+ 1047, 1049, 1051, 1052, 1053, 1054, 1055, 1056, 1058, 1059, 1060, 1061, 1062,
+ 1063, 1064, 1066, 1067, 1068, 1069, 1070, 1071, 1072, 1074, 1075, 1076, 1077,
+ 1078, 1079, 1087, 1091, 1094, 1095, 1109, 1112, 1126, 1127, 1129, 1133, 1134,
+ 1135, 1140, 1141, 1142, 1144, 1145, 1152, 1180, 1183, 1184, 1189, 1192, 1195,
+ 1197, 1200, 1204, 1205, 1207, 1227, 1228, 1229, 1230, 1231, 1232, 1233, 1234,
+ 1235, 1237, 1238, 1297, 1298, 1299, 1300, 1301, 1302, 1303, 1304, 1307, 1308,
+ 1309, 1310, 1311, 1312, 1353, 1391, 1395, 1398, 1410, 1411, 1421, 1424, 1470,
+ 1700, 1701, 1702, 1703, 1704, 1705, 1712, 1713, 1714, 1965, 1972];
+
+for meta in curvedPlatesDoubleIngots {
+    var item = itemUtils.getItem("gtadditions:ga_meta_item", meta) as IItemStack;
+    if(!isNull(item)) {
+        mods.jei.JEI.hide(item);
+    }
+}
+
+/* Hide as much of NuclearCraft's unused stuff as possible */
+val nc as IMod = loadedMods["nuclearcraft"];
+if(!isNull(nc)) {
+    val ncItems as IItemStack[] = nc.items;
+
+    for item in ncItems {
+        if(item.displayName has " Oxide" |
+           item.displayName has "MOX" |
+           item.displayName has "Molten Salt" |
+           item.displayName has "Eutectic" |
+           item.displayName has "Molten Depleted" |
+           item.displayName has "FLiBe" |
+           item.displayName has "Molten LE" |
+           item.displayName has "Molten HE" |
+           item.displayName has "Fluoride" |
+           item.definition.id has "fluid") {
+            mods.jei.JEI.removeAndHide(item);
+        }
+    }
+
+    /* Hide various unused NC fluids */
+    val containers = [<gregtech:meta_item_1:32405>,
+                      <gregtech:meta_item_1:32762>,
+                      <gregtech:meta_item_1:32406>] as IItemStack[];
+
+    for liquid in game.liquids {
+        if(liquid.displayName has "Eutectic" |
+           liquid.displayName has "Molten Depleted" |
+           liquid.displayName has "Molten LE" |
+           liquid.displayName has "Molten HE" |
+           liquid.displayName has "Fluoride" |
+           liquid.displayName has "FLiBe" |
+           liquid.name has "_23" | 
+           liquid.name has "_24" | 
+           liquid.name has "_25" ) {
+
+            // remove from various GT containers
+            for container in containers {
+                mods.jei.JEI.hide(container.withTag({Fluid: {FluidName: liquid.name, Amount: 1000}}));
+            }
+
+            // Different tag schemas...
+            mods.jei.JEI.hide(<ceramics:clay_bucket>.withTag({fluids: {FluidName: liquid.name, Amount: 1000}}));
+            mods.jei.JEI.hide(<forge:bucketfilled>.withTag({FluidName: liquid.name, Amount: 1000}));
+
+            // Hide the fluid too
+            mods.jei.JEI.hide(liquid*1000);
+        }
+    }
+}
+
+/* Hide all of AE2's facades (can still be crafted, just hiding from JEI) */
+val ae2 as IMod = loadedMods["appliedenergistics2"];
+if(!isNull(ae2)) {
+    val ae2Items as IItemStack[] = ae2.items;
+
+    for item in ae2Items {
+        if(item.displayName has "Cable Facade") {
+            mods.jei.JEI.hide(item);
+        }
+    }
+}


### PR DESCRIPTION
These items are unused in Omnifactory, and can be removed in configs to reduce load times and JEI clutter.