### PR TITLE
Update EnderIO and related mods

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -222,7 +222,7 @@
     },
     {
       "projectID": 231868,
-      "fileID": 2732682,
+      "fileID": 2822401,
       "required": true
     },
     {
@@ -292,7 +292,7 @@
     },
     {
       "projectID": 304346,
-      "fileID": 2732702,
+      "fileID": 2858815,
       "required": true
     },
     {
@@ -362,7 +362,7 @@
     },
     {
       "projectID": 312195,
-      "fileID": 2718576,
+      "fileID": 2858475,
       "required": true
     },
     {
@@ -712,7 +712,7 @@
     },
     {
       "projectID": 64578,
-      "fileID": 2732703,
+      "fileID": 2858816,
       "required": true
     },
     {

--- a/overrides/scripts/EnderIO.zs
+++ b/overrides/scripts/EnderIO.zs
@@ -1,0 +1,32 @@
+import mods.jei.JEI.removeAndHide as rh;
+
+// Construction Alloy
+recipes.remove(<enderio:block_alloy:9>);
+rh(<enderio:block_alloy:9>);
+
+recipes.remove(<enderio:item_alloy_ingot:9>);
+rh(<enderio:item_alloy_ingot:9>);
+
+recipes.remove(<enderio:item_alloy_nugget:9>);
+rh(<enderio:item_alloy_nugget:9>);
+
+rh(<enderio:item_material:46>); // Clippings and Trimmings
+rh(<enderio:item_material:47>); // Twigs and Prunings
+rh(<enderio:item_material:75>); // Infinity Goop
+rh(<enderio:item_material:76>); // Clay-Coated Glowstone
+
+// Blank Dark Steel Upgrade
+alloy.recipeBuilder()
+    .inputs([<gregtech:meta_item_1:12704>, <forestry:crafting_material>])
+    .outputs([<enderio:item_dark_steel_upgrade>])
+    .duration(100)
+    .EUt(20)
+    .buildAndRegister();
+
+// Glowstone Nano-Particles
+macerator.recipeBuilder()
+    .inputs([<minecraft:glowstone_dust>])
+    .outputs([<enderio:block_holy_fog>])
+    .duration(100)
+    .EUt(20)
+    .buildAndRegister();

--- a/overrides/scripts/EnderIO.zs
+++ b/overrides/scripts/EnderIO.zs
@@ -17,7 +17,7 @@ rh(<enderio:item_material:75>); // Infinity Goop
 rh(<enderio:item_material:76>); // Clay-Coated Glowstone
 rh(<enderio:item_material:21>); // Flour
 rh(<enderio:item_species_item_filter>); // Species Filter (Forestry)
-<ore:dustFlour>.remove(<enderio:item_material:21>); // Flour
+<ore:dustWheat>.remove(<enderio:item_material:21>); // Flour
 
 rh(<enderio:item_material:67>); // Enhanced Dye Blend
 rh(<enderio:item_material:52>); // Soul-Attuned Dye

--- a/overrides/scripts/EnderIO.zs
+++ b/overrides/scripts/EnderIO.zs
@@ -1,4 +1,5 @@
 import mods.jei.JEI.removeAndHide as rh;
+import crafttweaker.item.IItemStack;
 
 // Construction Alloy
 recipes.remove(<enderio:block_alloy:9>);
@@ -14,6 +15,67 @@ rh(<enderio:item_material:46>); // Clippings and Trimmings
 rh(<enderio:item_material:47>); // Twigs and Prunings
 rh(<enderio:item_material:75>); // Infinity Goop
 rh(<enderio:item_material:76>); // Clay-Coated Glowstone
+rh(<enderio:item_material:21>); // Flour
+rh(<enderio:item_species_item_filter>); // Species Filter (Forestry)
+<ore:dustFlour>.remove(<enderio:item_material:21>); // Flour
+
+rh(<enderio:item_material:67>); // Enhanced Dye Blend
+rh(<enderio:item_material:52>); // Soul-Attuned Dye
+rh(<enderio:item_material:50>); // Organic Black Dye
+rh(<enderio:item_material:49>); // Organic Brown Dye
+rh(<enderio:item_material:48>); // Organic Green Dye
+rh(<enderio:item_material:51>); // Industrial Dye Blend
+recipes.remove(<enderio:item_material:67>); // Enhanced Dye Blend
+recipes.remove(<enderio:item_material:51>); // Industrial Dye Blend
+
+recipes.remove(<enderio:item_material:55>); // Soulless Chassis
+rh(<enderio:item_material:55>);             // Soulless Chassis
+rh(<enderio:block_industrial_insulation>);  // Industrial Insulation
+
+rh(<enderio:item_material:69>);             // Simple Chassis Parts
+recipes.remove(<enderio:item_material:69>); // Simple Chassis Parts
+
+// Get rid of useless ingots
+val uselessIngots = [
+    0   // "CrudeSteel"
+    , 1 // "CrystallineAlloy"
+    , 2 // "MelodicAlloy"
+    , 4 // "CrystallinePinkSlime"
+    , 6 // "VividAlloy"
+] as int[];
+
+val variants = [
+    "block_alloy_endergy"
+    , "item_alloy_endergy_nugget"
+    , "item_alloy_endergy_ingot"
+] as string[];
+
+for metadata in uselessIngots {
+    for variant in variants {
+        var item = itemUtils.getItem("enderio:" + variant, metadata) as IItemStack;
+        if (!isNull(item)) {
+            recipes.remove(item);
+            rh(item);
+        }
+    }
+}
+
+// Grinding Balls
+for item in <enderio:item_alloy_ball:*>.items as IItemStack[] {
+    rh(item);
+    recipes.remove(item);
+}
+
+for item in <enderio:item_alloy_endergy_ball:*>.items as IItemStack[] {
+    rh(item);
+    recipes.remove(item);
+}
+
+var teBalls = [<enderio:item_material:57>, <enderio:item_material:58>, <enderio:item_material:59>] as IItemStack[];
+for item in teBalls {
+    rh(item);
+    recipes.remove(item);
+}
 
 // Blank Dark Steel Upgrade
 alloy.recipeBuilder()
@@ -30,3 +92,34 @@ macerator.recipeBuilder()
     .duration(100)
     .EUt(20)
     .buildAndRegister();
+
+// Solar Upgrades
+
+// Simple Solar
+recipes.remove(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiomachines:solar"}));
+recipes.addShapeless(
+    <enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiomachines:solar"})
+    , [<enderio:item_dark_steel_upgrade>, <solarflux:solar_panel_1>]
+);
+
+// Solar
+recipes.remove(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiomachines:solar1"}));
+recipes.addShapeless(
+    <enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiomachines:solar1"})
+    , [<enderio:item_dark_steel_upgrade>, <solarflux:solar_panel_2>]
+);
+
+// Solar II
+recipes.remove(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiomachines:solar2"}));
+recipes.addShapeless(
+    <enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiomachines:solar2"})
+    , [<enderio:item_dark_steel_upgrade>, <solarflux:solar_panel_3>]
+);
+
+// Solar III
+recipes.remove(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiomachines:solar3"}));
+recipes.addShapeless(
+    <enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiomachines:solar3"})
+    , [<enderio:item_dark_steel_upgrade>, <solarflux:solar_panel_4>]
+);
+

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -918,7 +918,6 @@ var gearsDisabled as IItemStack[][IOreDictEntry] = {
 	#gearWood
 	<ore:gearWood> : [
 		<appliedenergistics2:material:40>,
-		<enderio:item_material:9>,
 		<thermalfoundation:material:22>
 	]
 };


### PR DESCRIPTION
Bumps EnderIO and related mods to the latest version and fixes several recipes, Blank Dark Steel Upgrade being one of them.