### PR TITLE
Remove ZPMs from the jungle temple loot table

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -764,6 +764,11 @@
       "projectID": 322861,
       "fileID": 2762550,
       "required": true
+    },
+    {
+      "projectID": 255257,
+      "fileID": 2865495,
+      "required": true
     }
   ],
   "overrides": "overrides"

--- a/modlist.html
+++ b/modlist.html
@@ -149,4 +149,5 @@
 <li><a href="https://minecraft.curseforge.com/mc-mods/269024">The Lost Cities (by McJty)</a></li>
 <li><a href="https://minecraft.curseforge.com/mc-mods/278494">FoamFix for Minecraft (by asiekierka)</a></li>
 <li><a href="https://minecraft.curseforge.com/mc-mods/322861">PackagedExCrafting (by TheLMiffy1111)</a></li>
+<li><a href="https://minecraft.curseforge.com/mc-mods/255257">LootTweaker (by Daomephsta)</a></li>
 </ul>

--- a/overrides/config/loottweaker.cfg
+++ b/overrides/config/loottweaker.cfg
@@ -1,0 +1,11 @@
+# Configuration file
+
+general {
+    # Should LootTweaker warn about deprecated methods on world load? Resets if the version of LootTweaker is changed.
+    B:deprecationWarnings=true
+
+    # Do not touch!
+    S:lastCfgVersion=0.1.5
+}
+
+

--- a/overrides/scripts/LootTweaker.zs
+++ b/overrides/scripts/LootTweaker.zs
@@ -1,0 +1,9 @@
+import loottweaker.vanilla.loot.LootTables;
+import loottweaker.vanilla.loot.LootTable;
+import loottweaker.vanilla.loot.LootPool;
+
+// Remove Zero Point Modules from Jungle Temples
+val jungleTemple = LootTables.getTable("minecraft:chests/jungle_temple");
+val pool = jungleTemple.getPool("main");
+
+pool.removeEntry("#gregtech:loot_1xitem.meta_item@32599");


### PR DESCRIPTION
Prevents pre-charged Zero Point Modules from generating in jungle temples.

These things are OP and since the pack allows putting them in LV-LuV CEFs/CEUs they eliminate the need of setting up (at least early) power generation, a player can easily just loot himself a virtually infinite power source.

Adds LootTweaker 0.1.5 as dependency.