### PR TITLE
Unhide Micro Miner Cores/Frames and remove TE Sawdust

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -251,7 +251,6 @@ recipes.addShaped(<enderio:item_liquid_conduit:1> * 4, [
 	[<minecraft:glass>,<minecraft:glass>,<minecraft:glass>],
 	[<ore:itemConduitBinder>, <ore:itemConduitBinder>, <ore:itemConduitBinder>]]);
 assembler.recipeBuilder().inputs([<minecraft:glass> * 3, <ore:itemConduitBinder> * 6]).outputs([<enderio:item_liquid_conduit:1> * 8]).duration(80).EUt(16).buildAndRegister();
-macerator.recipeBuilder().inputs([<ore:logWood>]).outputs([<thermalfoundation:material:800> * 2]).duration(80).EUt(8).buildAndRegister();
 macerator.recipeBuilder().inputs([<minecraft:diamond>]).outputs([<gregtech:meta_item_1:2111>]).duration(80).EUt(8).buildAndRegister();
 macerator.recipeBuilder().inputs([<appliedenergistics2:material:7>]).outputs([<appliedenergistics2:material:8>]).duration(80).EUt(8).buildAndRegister();
 macerator.recipeBuilder().inputs([<enderio:item_material:16>]).outputs([<enderio:item_material:37>]).duration(500).EUt(16).buildAndRegister();

--- a/overrides/scripts/Electronics.zs
+++ b/overrides/scripts/Electronics.zs
@@ -912,8 +912,8 @@ pyro.recipeBuilder().inputs([<gregtech:meta_item_1:2106> * 16]).notConsumable(<g
 
 reactor.recipeBuilder().inputs(<metaitem:board.coated>).fluidInputs([<liquid:phenol> * 100]).outputs([<metaitem:board.phenolic>]).duration(100).EUt(8).buildAndRegister();
 
-assembler.findRecipe(8, [<thermalfoundation:material:800>, <gregtech:meta_item_1:32301>], [<liquid:glue> * 100]).remove();	
-assembler.findRecipe(8, [<thermalfoundation:material:800>, <gregtech:meta_item_1:32301>], [<liquid:bisphenol_a> * 100]).remove();	
+assembler.findRecipe(8, [<ore:dustWood>.firstItem, <gregtech:meta_item_1:32301>], [<liquid:glue> * 100]).remove();	
+assembler.findRecipe(8, [<ore:dustWood>.firstItem, <gregtech:meta_item_1:32301>], [<liquid:bisphenol_a> * 100]).remove();	
 
 recipes.removeByRecipeName("gregtech:small_coil_annealed_copper_steel");
 recipes.removeByRecipeName("gregtech:small_coil_copper_ferrite");

--- a/overrides/scripts/JetpacksAndEnergyStorage.zs
+++ b/overrides/scripts/JetpacksAndEnergyStorage.zs
@@ -535,13 +535,6 @@ recipes.addShaped(<thermalexpansion:frame:132>, [
 	[<gregtech:meta_item_1:14708>, null, <gregtech:meta_item_1:14708>],
 	[<thermalfoundation:material:359>, <gregtech:meta_item_1:14708>, <thermalfoundation:material:359>]]);
 
-mods.jei.JEI.addItem(<thermalexpansion:frame:130>);
-mods.jei.JEI.addItem(<thermalexpansion:frame:131>);
-mods.jei.JEI.addItem(<thermalexpansion:frame:132>);
-mods.jei.JEI.addItem(<thermalexpansion:frame:146>);
-mods.jei.JEI.addItem(<thermalexpansion:frame:147>);
-mods.jei.JEI.addItem(<thermalexpansion:frame:148>);
-
 // redstone cell frame (filled) => "microminer engine core"
 alloy.recipeBuilder()
     .inputs([<thermalexpansion:frame:130>, <minecraft:redstone_block> * 2])

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -357,6 +357,16 @@ var dustsDisabled as IItemStack[][IOreDictEntry] = {
 	#dustTitanium
 	<ore:dustTitanium> : [
 		<libvulpes:productdust:7>
+	],
+
+	#dustWood
+	<ore:dustWood>: [
+		<thermalfoundation:material:800>
+	],
+
+	#itemSawdust
+	<ore:itemSawdust>: [
+		<thermalfoundation:material:800>
 	]
 
 };
@@ -1593,7 +1603,6 @@ mods.jei.JEI.removeAndHide(<thermalfoundation:upgrade:256>);
 mods.jei.JEI.removeAndHide(<thermalfoundation:material:23>);
 mods.jei.JEI.removeAndHide(<thermalfoundation:material:27>);
 mods.jei.JEI.removeAndHide(<thermalfoundation:material:802>);
-mods.jei.JEI.removeAndHide(<thermalfoundation:material:800>);
 mods.jei.JEI.removeAndHide(<thermalfoundation:material:801>);
 mods.jei.JEI.removeAndHide(<thermalfoundation:material:657>);
 mods.jei.JEI.removeAndHide(<thermalfoundation:tool.hammer_silver>);
@@ -1653,7 +1662,7 @@ recipes.addShapeless(<thermalfoundation:material:166>, [<gregtech:meta_item_1:10
 recipes.addShapeless(<thermalfoundation:material:165>, [<gregtech:meta_item_1:10707>]);
 recipes.addShapeless(<draconicevolution:draconium_ingot>, [<gregtech:meta_item_1:10710>]);
 recipes.addShapeless(<draconicevolution:draconium_dust>, [<gregtech:meta_item_1:2710>]);
-
+recipes.addShapeless(<ore:dustWood>.firstItem, [<thermalfoundation:material:800>]);
 
 
 

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -1589,12 +1589,6 @@ mods.jei.JEI.removeAndHide(<theoneprobe:creativeprobe>);
 //Thermal Removals
 mods.jei.JEI.removeAndHide(<thermalexpansion:satchel:32000>);
 mods.jei.JEI.removeAndHide(<thermalexpansion:frame:129>);
-mods.jei.JEI.removeAndHide(<thermalexpansion:frame:130>);
-mods.jei.JEI.removeAndHide(<thermalexpansion:frame:131>);
-mods.jei.JEI.removeAndHide(<thermalexpansion:frame:132>);
-mods.jei.JEI.removeAndHide(<thermalexpansion:frame:146>);
-mods.jei.JEI.removeAndHide(<thermalexpansion:frame:147>);
-mods.jei.JEI.removeAndHide(<thermalexpansion:frame:148>);
 mods.jei.JEI.removeAndHide(<thermalfoundation:upgrade:256>);
 mods.jei.JEI.removeAndHide(<thermalfoundation:material:23>);
 mods.jei.JEI.removeAndHide(<thermalfoundation:material:27>);


### PR DESCRIPTION
Fixes Micro Miner Engine Cores/Frames being invisible in JEI.

Also removes the Thermal Expansion variant of Sawdust:
> Something I noticed while unhiding Micro Miner Engines.
Currently the TE Sawdust variant is 1:1 identical to the GTCE variant, and adds nothing but unnecessary clutter to JEI.

> Adds a recipe to convert the obsolete variant to the useful one.

Thanks to [Coffee](https://steamcommunity.com/id/nntoxic/) for reporting it.