### PR TITLE
Add extra S'n'S recipes taking better wafers

### DIFF
--- a/overrides/scripts/EnderIO.zs
+++ b/overrides/scripts/EnderIO.zs
@@ -208,31 +208,34 @@ mods.jei.JEI.addItem(doublecompressedoctadiccap);
 
 */
 
-var bonus = 4 as int;
+var bonus = 1 as int;
+var cost  = 20000 as int;
+
 for wafer in [<gregtech:meta_item_2:32441>, <gregtech:meta_item_2:32442>] as IItemStack[] {
+    bonus = bonus * 2;
+    cost  = cost  * 2;
+
     // Z-Logic Controller
     mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:41> * bonus, [
         <enderio:item_alloy_ingot:7> , <minecraft:skull:2>  , <enderio:item_alloy_ingot:7>
         , wafer                      , <minecraft:redstone> , wafer
-    ], 20000);
+    ], cost);
 
     // Ender Resonator
     mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:43> * bonus, [
         <enderio:item_alloy_ingot:7> , <enderio:block_enderman_skull> , <enderio:item_alloy_ingot:7>
         , wafer                      , <enderio:item_alloy_ingot:2>   , wafer
-    ], 20000);
+    ], cost);
 
-    // Skeleton Contractor
+    // Skeletal Contractor
     mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:45> * bonus, [
         <enderio:item_alloy_ingot:7> , <minecraft:skull> , <enderio:item_alloy_ingot:7>
         , <minecraft:rotten_flesh>   , wafer             , <minecraft:rotten_flesh>
-    ], 20000);
+    ], cost);
 
     // Guardian Diode
     mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:56> * bonus, [
         <enderio:item_alloy_ingot:1>      , <minecraft:prismarine_shard> , <enderio:item_alloy_ingot:1>
         , <minecraft:prismarine_crystals> , wafer                        , <minecraft:prismarine_crystals>
-    ], 20000);
-
-    bonus = bonus * 2;
+    ], cost);
 }

--- a/overrides/scripts/EnderIO.zs
+++ b/overrides/scripts/EnderIO.zs
@@ -201,3 +201,38 @@ mods.jei.JEI.addItem(compressedoctadiccap);
 mods.jei.JEI.addItem(doublecompressedoctadiccap);
 <contenttweaker:compressedoctadiccapacitor>.addTooltip(format.white("Put the item into a crafting window if it has no lore"));
 <contenttweaker:doublecompressedoctadiccapacitor>.addTooltip(format.white("Put the item into a crafting window if it has no lore"));
+
+/*
+
+  Extra Slice'n'Splice Recipes
+
+*/
+
+var bonus = 4 as int;
+for wafer in [<gregtech:meta_item_2:32441>, <gregtech:meta_item_2:32442>] as IItemStack[] {
+    // Z-Logic Controller
+    mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:41> * bonus, [
+        <enderio:item_alloy_ingot:7> , <minecraft:skull:2>  , <enderio:item_alloy_ingot:7>
+        , wafer                      , <minecraft:redstone> , wafer
+    ], 20000);
+
+    // Ender Resonator
+    mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:43> * bonus, [
+        <enderio:item_alloy_ingot:7> , <enderio:block_enderman_skull> , <enderio:item_alloy_ingot:7>
+        , wafer                      , <enderio:item_alloy_ingot:2>   , wafer
+    ], 20000);
+
+    // Skeleton Contractor
+    mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:45> * bonus, [
+        <enderio:item_alloy_ingot:7> , <minecraft:skull> , <enderio:item_alloy_ingot:7>
+        , <minecraft:rotten_flesh>   , wafer             , <minecraft:rotten_flesh>
+    ], 20000);
+
+    // Guardian Diode
+    mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:56> * bonus, [
+        <enderio:item_alloy_ingot:1>      , <minecraft:prismarine_shard> , <enderio:item_alloy_ingot:1>
+        , <minecraft:prismarine_crystals> , wafer                        , <minecraft:prismarine_crystals>
+    ], 20000);
+
+    bonus = bonus * 2;
+}


### PR DESCRIPTION
Adds additional recipes for Z-Logic Controllers, Ender Resonators, Skeletal Contractors and Guardian Diodes taking Glowstone-Doped and Naquadah wafers and providing better yield. Removes the post-tank dependency on regular wafers. Helps with the zombie head grind.

1x with regular wafers, 2x with Glowstone-Doped, 4x with Naquadah.

Might be worth it buffing up to 1/4/8.

Closes #177.

![image](https://user-images.githubusercontent.com/22255622/73612997-3be87800-4645-11ea-9f60-2e0660891996.png)
