### PR TITLE
Move SimplyJetpacks HUD to top center

### DIFF
--- a/overrides/config/simplyjetpacks-client.cfg
+++ b/overrides/config/simplyjetpacks-client.cfg
@@ -38,7 +38,7 @@
     B:"Exact fuel amounts in HUD"=false
 
     # The base position of the HUD on the screen. 0 = top left, 1 = top center, 2 = top right, 3 = left, 4 = right, 5 = bottom left, 6 = bottom right
-    I:"HUD Base Position"=0
+    I:"HUD Base Position"=1
 
     # The HUD display will be shifted horizontally by this value. This value may be negative.
     I:"HUD Offset - X"=0


### PR DESCRIPTION
Current SimplyJetpacks GUI overlaps other mod when the player has it equipped.
https://imgur.com/PqgJvVk

afaik, there are no other HUDs in top center so I moved it in there.