### PR TITLE
Move hand crafted recipes into the loop, so that all wrenches can be …

### DIFF
--- a/overrides/scripts/Electronics.zs
+++ b/overrides/scripts/Electronics.zs
@@ -917,14 +917,13 @@ for i, wrench in wrenches {
     // Modularium Machine Casing
     recipes.addShaped("of_modular_casing_wrench"+i, <modularmachinery:blockcasing> *2, [
         [<modularmachinery:itemmodularium>, <modularmachinery:itemmodularium>, <modularmachinery:itemmodularium>], 
-        [<modularmachinery:itemmodularium>,             wrench           , <modularmachinery:itemmodularium>], 
-        [<modularmachinery:itemmodularium>, <modularmachinery:itemmodularium>,  
-        <modularmachinery:itemmodularium>]]);
+        [<modularmachinery:itemmodularium>,               wrench             , <modularmachinery:itemmodularium>], 
+        [<modularmachinery:itemmodularium>, <modularmachinery:itemmodularium>, <modularmachinery:itemmodularium>]]);
 
     // LuV Machine Casing
     recipes.addShaped("of_luv_casing_wrench"+i, <gregtech:machine_casing:6>, [
         [<ore:plateLumium>, <ore:plateLumium>, <ore:plateLumium>], 
-        [<ore:plateLumium>,             wrench           , <ore:plateLumium>], 
+        [<ore:plateLumium>,       wrench     , <ore:plateLumium>], 
         [<ore:plateLumium>, <ore:plateLumium>, <ore:plateLumium>]]);
 }
 

--- a/overrides/scripts/Electronics.zs
+++ b/overrides/scripts/Electronics.zs
@@ -913,6 +913,19 @@ for i, wrench in wrenches {
         [<moreplates:neutronium_plate>, <moreplates:neutronium_plate>, <moreplates:neutronium_plate>], 
         [<moreplates:neutronium_plate>,             wrench           , <moreplates:neutronium_plate>], 
         [<moreplates:neutronium_plate>, <moreplates:neutronium_plate>, <moreplates:neutronium_plate>]]);
+
+    // Modularium Machine Casing
+    recipes.addShaped("of_modular_casing_wrench"+i, <modularmachinery:blockcasing> *2, [
+        [<modularmachinery:itemmodularium>, <modularmachinery:itemmodularium>, <modularmachinery:itemmodularium>], 
+        [<modularmachinery:itemmodularium>,             wrench           , <modularmachinery:itemmodularium>], 
+        [<modularmachinery:itemmodularium>, <modularmachinery:itemmodularium>,  
+        <modularmachinery:itemmodularium>]]);
+
+    // LuV Machine Casing
+    recipes.addShaped("of_luv_casing_wrench"+i, <gregtech:machine_casing:6>, [
+        [<ore:plateLumium>, <ore:plateLumium>, <ore:plateLumium>], 
+        [<ore:plateLumium>,             wrench           , <ore:plateLumium>], 
+        [<ore:plateLumium>, <ore:plateLumium>, <ore:plateLumium>]]);
 }
 
 //MAX Casing - Assembler

--- a/overrides/scripts/Endgame.zs
+++ b/overrides/scripts/Endgame.zs
@@ -201,10 +201,6 @@ fusion_reactor.findRecipe(4096, [null], [<liquid:deuterium> * 125, <liquid:triti
 
 recipes.remove(<gregtech:machine_casing:6>);
 recipes.remove(<gregtech:machine:506>);
-recipes.addShaped(<gregtech:machine_casing:6>, [
-	[<ore:plateLumium>, <ore:plateLumium>, <ore:plateLumium>], 
-	[<ore:plateLumium>, <gregtech:meta_tool:8>, <ore:plateLumium>], 
-	[<ore:plateLumium>, <ore:plateLumium>, <ore:plateLumium>]]);
 recipes.addShaped(<gregtech:machine:506>, [
 	[<ore:platePlastic>, <ore:plateLumium>, <ore:platePlastic>], 
 	[<ore:cableGtSingleVanadiumGallium>, <gregtech:machine_casing:6>, <ore:cableGtSingleVanadiumGallium>]]);

--- a/overrides/scripts/Microverse.zs
+++ b/overrides/scripts/Microverse.zs
@@ -94,7 +94,6 @@ recipes.addShaped(<modularmachinery:blockenergyoutputhatch:7>, [[null, <modularm
 
 //Casing
 recipes.remove(<modularmachinery:blockcasing>);
-recipes.addShaped(<modularmachinery:blockcasing> * 2, [[<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>],[<modularmachinery:itemmodularium>,<gregtech:meta_tool:8>,<modularmachinery:itemmodularium>],[<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>,<modularmachinery:itemmodularium>]]);
 assembler.recipeBuilder().inputs([<modularmachinery:itemmodularium> * 4]).outputs([<modularmachinery:blockcasing>]).duration(200).EUt(30).buildAndRegister();
 
 // Machine Vent


### PR DESCRIPTION
…used.

As talked about in discord, these two casings have their gt recipes removed, and then added via crafttweaker, so the ore dict does not work properly. Adding to the loop so all wrenches can be used.