### PR TITLE
Make booster card infinite, adjust recipe

### DIFF
--- a/overrides/config/AE2WirelessTerminals.cfg
+++ b/overrides/config/AE2WirelessTerminals.cfg
@@ -29,7 +29,7 @@ general {
     I:EndermanBoosterDropChance=5
 
     # Will Enderman randomly drop infinity booster cards on death? [default: true]
-    B:EndermanDropBoosters=true
+    B:EndermanDropBoosters=false
 
     # Amount of Infinity Energy Consumed every 10 ticks when not in range of a WAP [range: 5 ~ 100, default: 15]
     I:InfinityEnergyDrainAmount=15
@@ -38,13 +38,13 @@ general {
     I:InfinityEnergyPerBooster=100
 
     # If true, then simply inserting 1 Infinity Booster Card into the slot, will give limitless infinite range. [default: false]
-    B:UseOldInfinityMechanic=false
+    B:UseOldInfinityMechanic=true
 
     # Percentage chance that booster card will drop upon killing a wither. (between 1 and 100) [range: 1 ~ 100, default: 30]
     I:WitherBoosterDropChance=30
 
     # Should Withers drop Infinity Booster Card? [default: true]
-    B:WitherDropsBooster=true
+    B:WitherDropsBooster=false
 }
 
 

--- a/overrides/scripts/AE2.zs
+++ b/overrides/scripts/AE2.zs
@@ -338,7 +338,6 @@ recipes.addShaped(<appliedenergistics2:material:38>, [
 //AE2 Wireless Terminal, Infinity Booster Card
 recipes.removeByRecipeName("ae2wtlib:booster_card_old");
 recipes.addShaped(<ae2wtlib:infinity_booster_card>, [
-	[<ore:circuitElite>, null, <ore:circuitElite>],
+	[<gregtech:meta_item_1:32724>, null, <gregtech:meta_item_1:32724>],
 	[null, <appliedenergistics2:material:41>, null],
-	[null, null, null]
-	]);
+	[null, null, null]]);

--- a/overrides/scripts/AE2.zs
+++ b/overrides/scripts/AE2.zs
@@ -335,3 +335,10 @@ recipes.addShaped(<appliedenergistics2:material:38>, [
 	[<appliedenergistics2:material:37>, <ore:circuitExtreme>, <appliedenergistics2:material:37>],
 	[<appliedenergistics2:material:22>, <appliedenergistics2:material:37>, <appliedenergistics2:material:22>]]);
 	
+//AE2 Wireless Terminal, Infinity Booster Card
+recipes.removeByRecipeName("ae2wtlib:booster_card_old");
+recipes.addShaped(<ae2wtlib:infinity_booster_card>, [
+	[<draconicevolution:awakened_core>, null, <draconicevolution:awakened_core>],
+	[null, <appliedenergistics2:material:41>, null],
+	[null, null, null]
+	]);

--- a/overrides/scripts/AE2.zs
+++ b/overrides/scripts/AE2.zs
@@ -338,7 +338,7 @@ recipes.addShaped(<appliedenergistics2:material:38>, [
 //AE2 Wireless Terminal, Infinity Booster Card
 recipes.removeByRecipeName("ae2wtlib:booster_card_old");
 recipes.addShaped(<ae2wtlib:infinity_booster_card>, [
-	[<draconicevolution:awakened_core>, null, <draconicevolution:awakened_core>],
+	[<ore:circuitElite>, null, <ore:circuitElite>],
 	[null, <appliedenergistics2:material:41>, null],
 	[null, null, null]
 	]);


### PR DESCRIPTION
Closes #328 
Adjusts the config of wireless AE to make the Infinity Booster Card last forever, and also removes it as a drop from endermen and the wither.

Also as Neeve mentioned in the issue, adjusts the recipe of the booster card, to make it slightly more difficult. Right now, I just replaced the two singularities with IV tier circuits. Let me know if there is a more suitable material.