### PR TITLE
Add Space Suit Upgrade Recipes

### DIFF
--- a/overrides/scripts/AdvRocketry.zs
+++ b/overrides/scripts/AdvRocketry.zs
@@ -393,3 +393,22 @@ mods.jei.JEI.removeAndHide(<advancedrocketry:ic:1>);
 mods.jei.JEI.removeAndHide(<advancedrocketry:satelliteidchip>);
 recipes.remove(<advancedrocketry:ic:1>);
 recipes.remove(<advancedrocketry:satelliteidchip>);
+
+//Space Suit Upgrades
+//Hover Upgrade
+assembler.recipeBuilder().inputs(<enderio:item_soul_vial:1>.withTag({entityId: "minecraft:bat"}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>).fluidInputs(<liquid:glowstone>*1296).outputs(<advancedrocketry:itemupgrade:0>).duration(400).EUt(100).buildAndRegister();
+
+//Bionic Leg upgrade
+assembler.recipeBuilder().inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:jumpboost3", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>).outputs(<advancedrocketry:itemupgrade:2>).duration(400).EUt(100).buildAndRegister();
+
+//Flight Speed Control Upgrade
+assembler.recipeBuilder().inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:glide", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>).outputs(<advancedrocketry:itemupgrade:1>).duration(400).EUt(100).buildAndRegister();
+
+//Anti Fog visor
+assembler.recipeBuilder().inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:nightvision", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>).outputs(<advancedrocketry:itemupgrade:4>).duration(400).EUt(100).buildAndRegister();
+
+//Padded Landing Boots
+assembler.recipeBuilder().inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:energyupgrade4", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>).outputs(<advancedrocketry:itemupgrade:3>).duration(400).EUt(100).buildAndRegister();
+
+//Atmospheric sensor
+assembler.recipeBuilder().inputs(<gregtech:meta_item_1:32691>, <enderio:item_dark_steel_upgrade>).fluidInputs(<liquid:soldering_alloy>*288).outputs(<advancedrocketry:atmanalyser>).duration(200).EUt(100).buildAndRegister();

--- a/overrides/scripts/AdvRocketry.zs
+++ b/overrides/scripts/AdvRocketry.zs
@@ -396,19 +396,50 @@ recipes.remove(<advancedrocketry:satelliteidchip>);
 
 //Space Suit Upgrades
 //Hover Upgrade
-assembler.recipeBuilder().inputs(<enderio:item_soul_vial:1>.withTag({entityId: "minecraft:bat"}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>).fluidInputs(<liquid:glowstone>*1296).outputs(<advancedrocketry:itemupgrade:0>).duration(400).EUt(100).buildAndRegister();
+assembler.recipeBuilder()
+	.inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:glide", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>)
+	.outputs(<advancedrocketry:itemupgrade:0>)
+	.duration(400)
+	.EUt(100)
+	.buildAndRegister();
 
 //Bionic Leg upgrade
-assembler.recipeBuilder().inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:jumpboost3", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>).outputs(<advancedrocketry:itemupgrade:2>).duration(400).EUt(100).buildAndRegister();
+assembler.recipeBuilder()
+	.inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:speedboost3", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>)
+	.outputs(<advancedrocketry:itemupgrade:2>)
+	.duration(400)
+	.EUt(100)
+	.buildAndRegister();
 
 //Flight Speed Control Upgrade
-assembler.recipeBuilder().inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:glide", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>).outputs(<advancedrocketry:itemupgrade:1>).duration(400).EUt(100).buildAndRegister();
+assembler.recipeBuilder()
+	.inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:travel", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>)
+	.outputs(<advancedrocketry:itemupgrade:1>)
+	.duration(400)
+	.EUt(100)
+	.buildAndRegister();
 
 //Anti Fog visor
-assembler.recipeBuilder().inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:nightvision", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>).outputs(<advancedrocketry:itemupgrade:4>).duration(400).EUt(100).buildAndRegister();
+assembler.recipeBuilder()
+	.inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:nightvision", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>)
+	.outputs(<advancedrocketry:itemupgrade:4>)
+	.duration(400)
+	.EUt(100)
+	.buildAndRegister();
 
 //Padded Landing Boots
-assembler.recipeBuilder().inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:energyupgrade4", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>).outputs(<advancedrocketry:itemupgrade:3>).duration(400).EUt(100).buildAndRegister();
+assembler.recipeBuilder()
+	.inputs(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderio:energyupgrade4", "enderio:enabled": 1 as byte}), <contenttweaker:radiationlayer>, <contenttweaker:pressurelayer>)
+	.outputs(<advancedrocketry:itemupgrade:3>)
+	.duration(400)
+	.EUt(100)
+	.buildAndRegister();
 
 //Atmospheric sensor
-assembler.recipeBuilder().inputs(<gregtech:meta_item_1:32691>, <enderio:item_dark_steel_upgrade>).fluidInputs(<liquid:soldering_alloy>*288).outputs(<advancedrocketry:atmanalyser>).duration(200).EUt(100).buildAndRegister();
+assembler.recipeBuilder()
+	.inputs(<gregtech:meta_item_1:32691>, <enderio:item_dark_steel_upgrade>)
+	.fluidInputs(<liquid:soldering_alloy>*288)
+	.outputs(<advancedrocketry:atmanalyser>)
+	.duration(200)
+	.EUt(100)
+	.buildAndRegister();

--- a/overrides/scripts/AdvRocketry.zs
+++ b/overrides/scripts/AdvRocketry.zs
@@ -437,8 +437,7 @@ assembler.recipeBuilder()
 
 //Atmospheric sensor
 assembler.recipeBuilder()
-	.inputs(<gregtech:meta_item_1:32691>, <enderio:item_dark_steel_upgrade>)
-	.fluidInputs(<liquid:soldering_alloy>*288)
+	.inputs(<enderio:item_dark_steel_upgrade>, <gregtech:meta_item_1:32691>)
 	.outputs(<advancedrocketry:atmanalyser>)
 	.duration(200)
 	.EUt(100)


### PR DESCRIPTION
Adds recipes for the space suit upgrades. Since Enderio was updated in the pack and added its own upgrades, I simply made most of the recipes use the enderio upgrades. They are currently consumed, but that can be changed if desired. All recipes require MV voltage, as that is about the time that the player would be going to the moon. The recipes themselves are not the greatest, so let me know if you want any to change.

Also, I don't know exactly what the atmospheric sensor is for, so its recipe might need changing as well.