### PR TITLE
Split Dense Ores and Exquisite Gems into separate files

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -617,6 +617,8 @@ autoclave.recipeBuilder().inputs([<ore:dustQuartzite>]).fluidInputs([<liquid:wat
 	<ore:gemExquisiteRutile>);mods.jei.JEI.removeAndHide(
 	<ore:gemExquisiteLazurite>);
 
+mods.jei.JEI.removeAndHide(<ore:gemFlawedCoke>);
+mods.jei.JEI.removeAndHide(<ore:gemChippedCoke>);
 mods.jei.JEI.removeAndHide(<ore:gemFlawlessLapis>);
 mods.jei.JEI.removeAndHide(<ore:gemFlawlessCoke>);
 mods.jei.JEI.removeAndHide(<ore:gemExquisiteLapis>);

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -616,6 +616,11 @@ autoclave.recipeBuilder().inputs([<ore:dustQuartzite>]).fluidInputs([<liquid:wat
 	<ore:gemExquisiteGreenSapphire>);mods.jei.JEI.removeAndHide(
 	<ore:gemExquisiteRutile>);mods.jei.JEI.removeAndHide(
 	<ore:gemExquisiteLazurite>);
+
+mods.jei.JEI.removeAndHide(<ore:gemFlawlessLapis>);
+mods.jei.JEI.removeAndHide(<ore:gemFlawlessCoke>);
+mods.jei.JEI.removeAndHide(<ore:gemExquisiteLapis>);
+mods.jei.JEI.removeAndHide(<ore:gemExquisiteCoke>);
 mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:8209>);
 
 furnace.setFuel(<gregtech:meta_item_1:10204>, 1200);

--- a/overrides/scripts/Endgame.zs
+++ b/overrides/scripts/Endgame.zs
@@ -1,15 +1,5 @@
 import mods.gregtech.recipe.RecipeMap;
 
-//Dense Ores
-reactor.recipeBuilder().inputs(<densemetals:dense_redstone_ore>).fluidInputs(<liquid:nitric_acid> * 1000).outputs([<gregtech:ore_redstone_0> * 16]).duration(200).EUt(500).buildAndRegister();
-reactor.recipeBuilder().inputs(<densemetals:dense_emerald_ore>).fluidInputs(<liquid:nitric_acid> * 1000).outputs([<gregtech:ore_emerald_0> * 16]).duration(200).EUt(500).buildAndRegister();
-reactor.recipeBuilder().inputs(<densemetals:dense_diamond_ore>).fluidInputs(<liquid:nitric_acid> * 1000).outputs([<gregtech:ore_diamond_0> * 16]).duration(200).EUt(500).buildAndRegister();
-reactor.recipeBuilder().inputs(<densemetals:dense_iron_ore>).fluidInputs(<liquid:nitric_acid> * 1000).outputs([<gregtech:ore_iron_0> * 16]).duration(200).EUt(500).buildAndRegister();
-reactor.recipeBuilder().inputs(<densemetals:dense_lapis_ore>).fluidInputs(<liquid:nitric_acid> * 1000).outputs([<gregtech:ore_lapis_0> * 16]).duration(200).EUt(500).buildAndRegister();
-reactor.recipeBuilder().inputs(<densemetals:dense_gold_ore>).fluidInputs(<liquid:nitric_acid> * 1000).outputs([<gregtech:ore_gold_0> * 16]).duration(200).EUt(500).buildAndRegister();
-reactor.recipeBuilder().inputs(<densemetals:dense_coal_ore>).fluidInputs(<liquid:nitric_acid> * 1000).outputs([<gregtech:ore_coal_0> * 16]).duration(200).EUt(500).buildAndRegister();
-reactor.recipeBuilder().inputs(<contenttweaker:denseoilshale>).fluidInputs(<liquid:nitric_acid> * 1000).outputs([<gregtech:ore_oilsands_0:2> * 16]).duration(200).EUt(500).buildAndRegister();
-
 <deepmoblearning:glitch_fragment>.addTooltip(format.aqua(format.italic("Obtained by crushing Glitch Hearts against Obsidian.")));
 <appliedenergistics2:material:1>.addTooltip(format.aqua(format.italic("Obtained by charging with RF power in the AE2 Charger.")));
 
@@ -53,40 +43,6 @@ recipes.addShaped(<advancedrocketry:satelliteprimaryfunction:1>, [
 	[null,<advancedrocketry:satelliteprimaryfunction>,null],
 	[<ore:plateStainlessSteel>,<metaitem:sensor.hv>,<ore:plateStainlessSteel>],
 	[null,<ore:plateStainlessSteel>,null]]);	
-	
-//Cutting Gemstones
-
-saw.recipeBuilder().inputs([<ore:gemExquisiteEmerald>]).fluidInputs([<liquid:water> * 90]).outputs([<ore:gemFlawlessEmerald>.firstItem * 2]).duration(120).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemExquisiteEmerald>]).fluidInputs([<liquid:distilled_water> * 67]).outputs([<ore:gemFlawlessEmerald>.firstItem * 2]).duration(78).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemExquisiteEmerald>]).fluidInputs([<liquid:lubricant> * 22]).outputs(<ore:gemFlawlessEmerald>.firstItem * 2).duration(30).EUt(300).buildAndRegister();
-
-saw.recipeBuilder().inputs([<ore:gemFlawlessEmerald>]).fluidInputs([<liquid:water> * 90]).outputs([<ore:gemEmerald>.firstItem * 4]).duration(120).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemFlawlessEmerald>]).fluidInputs([<liquid:distilled_water> * 67]).outputs([<ore:gemEmerald>.firstItem * 4]).duration(78).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemFlawlessEmerald>]).fluidInputs([<liquid:lubricant> * 22]).outputs([<ore:gemEmerald>.firstItem * 4]).duration(30).EUt(300).buildAndRegister();
-
-saw.recipeBuilder().inputs([<ore:gemExquisiteDiamond>]).fluidInputs([<liquid:water> * 90]).outputs([<ore:gemFlawlessDiamond>.firstItem * 2]).duration(120).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemExquisiteDiamond>]).fluidInputs([<liquid:distilled_water> * 67]).outputs([<ore:gemFlawlessDiamond>.firstItem * 2]).duration(78).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemExquisiteDiamond>]).fluidInputs([<liquid:lubricant> * 22]).outputs(<ore:gemFlawlessDiamond>.firstItem * 2).duration(30).EUt(300).buildAndRegister();
-
-saw.recipeBuilder().inputs([<ore:gemFlawlessDiamond>]).fluidInputs([<liquid:water> * 90]).outputs([<ore:gemDiamond>.firstItem * 4]).duration(120).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemFlawlessDiamond>]).fluidInputs([<liquid:distilled_water> * 67]).outputs([<ore:gemDiamond>.firstItem * 4]).duration(78).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemFlawlessDiamond>]).fluidInputs([<liquid:lubricant> * 22]).outputs([<ore:gemDiamond>.firstItem * 4]).duration(30).EUt(300).buildAndRegister();
-
-saw.recipeBuilder().inputs([<ore:gemExquisiteRuby>]).fluidInputs([<liquid:water> * 90]).outputs([<ore:gemFlawlessRuby>.firstItem * 2]).duration(120).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemExquisiteRuby>]).fluidInputs([<liquid:distilled_water> * 67]).outputs([<ore:gemFlawlessRuby>.firstItem * 2]).duration(78).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemExquisiteRuby>]).fluidInputs([<liquid:lubricant> * 22]).outputs(<ore:gemFlawlessRuby>.firstItem * 2).duration(30).EUt(300).buildAndRegister();
-
-saw.recipeBuilder().inputs([<ore:gemFlawlessRuby>]).fluidInputs([<liquid:water> * 90]).outputs([<ore:gemRuby>.firstItem * 4]).duration(120).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemFlawlessRuby>]).fluidInputs([<liquid:distilled_water> * 67]).outputs([<ore:gemRuby>.firstItem * 4]).duration(78).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemFlawlessRuby>]).fluidInputs([<liquid:lubricant> * 22]).outputs([<ore:gemRuby>.firstItem * 4]).duration(30).EUt(300).buildAndRegister();
-
-saw.recipeBuilder().inputs([<ore:gemExquisiteLapis>]).fluidInputs([<liquid:water> * 90]).outputs([<ore:gemFlawlessLapis>.firstItem * 2]).duration(120).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemExquisiteLapis>]).fluidInputs([<liquid:distilled_water> * 67]).outputs([<ore:gemFlawlessLapis>.firstItem * 2]).duration(78).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemExquisiteLapis>]).fluidInputs([<liquid:lubricant> * 22]).outputs(<ore:gemFlawlessLapis>.firstItem * 2).duration(30).EUt(300).buildAndRegister();
-
-saw.recipeBuilder().inputs([<ore:gemFlawlessLapis>]).fluidInputs([<liquid:water> * 90]).outputs([<ore:gemLapis>.firstItem * 12]).duration(120).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemFlawlessLapis>]).fluidInputs([<liquid:distilled_water> * 67]).outputs([<ore:gemLapis>.firstItem * 12]).duration(78).EUt(300).buildAndRegister();
-saw.recipeBuilder().inputs([<ore:gemFlawlessLapis>]).fluidInputs([<liquid:lubricant> * 22]).outputs([<ore:gemLapis>.firstItem * 12]).duration(30).EUt(300).buildAndRegister();
 
 //Wetware Boards
 

--- a/overrides/scripts/OreProcessing/DenseOres.zs
+++ b/overrides/scripts/OreProcessing/DenseOres.zs
@@ -1,0 +1,48 @@
+import crafttweaker.item.IItemStack;
+import crafttweaker.liquid.ILiquidStack;
+import crafttweaker.oredict.IOreDictEntry;
+import mods.gregtech.recipe.RecipeMap;
+
+/*
+	This file provides compatibility for DenseMetals.
+	Adds ore dictionary entries for dense ores.
+	Registers chemical reactor recipes to turn one dense ore into 16 regular ores.
+
+	denseOres is an associative array:
+	{
+		ore_dictionary_entry : [ dense_ore_stack, regular_ore_stack ]
+	}
+*/
+
+val denseOres as IItemStack[][IOreDictEntry] = {
+	<ore:denseOreRedstone>   : [ <densemetals:dense_redstone_ore> , <gregtech:ore_redstone_0>   ]
+	, <ore:denseOreEmerald>  : [ <densemetals:dense_emerald_ore>  , <gregtech:ore_emerald_0>    ]
+	, <ore:denseOreDiamond>  : [ <densemetals:dense_diamond_ore>  , <gregtech:ore_diamond_0>    ]
+	, <ore:denseOreIron>     : [ <densemetals:dense_iron_ore>     , <gregtech:ore_iron_0>       ]
+	, <ore:denseOreLapis>    : [ <densemetals:dense_lapis_ore>    , <gregtech:ore_lapis_0>      ]
+	, <ore:denseOreGold>     : [ <densemetals:dense_gold_ore>     , <gregtech:ore_gold_0>       ]
+	, <ore:denseOreCoal>     : [ <densemetals:dense_coal_ore>     , <gregtech:ore_coal_0>       ]
+	, <ore:denseOreOilsands> : [ <contenttweaker:denseoilshale>   , <gregtech:ore_oilsands_0:2> ]
+};
+
+val fluidCatalyst = <liquid:nitric_acid> * 1000;
+val regularOrePerDense = 16;
+val recipeDuration = 200;
+val recipeEUt = 500;
+
+for oreDictEntry, itemStacks in denseOres {
+	val denseOreStack = itemStacks[0] as IItemStack;
+	val regularOreStack = itemStacks[1] as IItemStack;
+
+	// Add ore dictionary entry
+	oreDictEntry.add(denseOreStack);
+
+	// Chemical reactor recipe, 1 dense -> 16 regular
+	reactor.recipeBuilder()
+		.inputs(oreDictEntry)
+		.fluidInputs(fluidCatalyst)
+		.outputs([regularOreStack * regularOrePerDense])
+		.duration(recipeDuration)
+		.EUt(recipeEUt)
+		.buildAndRegister();
+}

--- a/overrides/scripts/OreProcessing/ExquisiteGems.zs
+++ b/overrides/scripts/OreProcessing/ExquisiteGems.zs
@@ -21,7 +21,8 @@ import mods.gregtech.recipe.RecipeMap;
 	]
 
 	cuttingFluidTypes defines cutting fluids.
-	cuttingFluidDurations defines durations for the aforementioned fluids.
+	cuttingFluidDurations defines recipe durations for said fluids.
+	cuttingFluidAmounts defines amounts of said fluids per recipe.
 	cuttingRecipeEUt defines... guess what.
 */
 

--- a/overrides/scripts/OreProcessing/ExquisiteGems.zs
+++ b/overrides/scripts/OreProcessing/ExquisiteGems.zs
@@ -1,0 +1,120 @@
+import crafttweaker.item.IItemStack;
+import crafttweaker.liquid.ILiquidStack;
+import crafttweaker.oredict.IOreDictEntry;
+import mods.gregtech.recipe.RecipeMap;
+
+/*
+	This file adds recipes for cutting exquisite and flawless gems.
+	Additionally adjusts amounts of dusts from pulverizing both.
+	
+	1 Exquisite Gem -> 2 Flawless Gems
+	1 Flawless  Gem -> 4 Regular Gems
+
+	Thus 1 Exquisite Gem = 8 Regular Gems.
+
+	1 Exquisite Gem -> 8 Gem Dust
+	1 Flawless  Gem -> 4 Gem Dust
+
+	gemVariants is a 2D array of ore dictionary entries, it defines gem variants as follows:
+	[
+		[ exquisite_gem, flawless_gem, regular_gem, regular_gem_dust ]
+	]
+
+	cuttingFluidTypes defines cutting fluids.
+	cuttingFluidDurations defines durations for the aforementioned fluids.
+	cuttingRecipeEUt defines... guess what.
+*/
+
+val gemVariants as IOreDictEntry[][] = [
+	[
+		<ore:gemExquisiteEmerald> 
+		, <ore:gemFlawlessEmerald> 
+		, <ore:gemEmerald>
+		, <ore:dustEmerald>
+	]
+	, [
+		<ore:gemExquisiteDiamond> 
+		, <ore:gemFlawlessDiamond> 
+		, <ore:gemDiamond>
+		, <ore:dustDiamond>
+	]
+	, [
+		<ore:gemExquisiteRuby>
+		, <ore:gemFlawlessRuby>
+		, <ore:gemRuby>
+		, <ore:dustRuby>
+	]
+];
+
+val cuttingFluidTypes as ILiquidStack[] = [
+	<liquid:water>
+	, <liquid:distilled_water>
+	, <liquid:lubricant>
+];
+
+val cuttingFluidDurations as int[] = [
+	120, 78, 30
+];
+
+val cuttingFluidAmounts as int[] = [
+	90, 67, 22
+];
+
+val cuttingRecipeEUt = 300;
+
+for variant in gemVariants {
+	for fluidId, _ in cuttingFluidTypes {
+		val cuttingFluid = cuttingFluidTypes[fluidId];
+		val cuttingFluidAmount = cuttingFluidAmounts[fluidId];
+		val recipeDuration = cuttingFluidDurations[fluidId];
+
+		val gemExquisite = variant[0];
+		val gemFlawless = variant[1];
+		val gemRegular = variant[2];
+		val gemDust = variant[3];
+
+		// Cut 1 Exquisite into 2 Flawless
+		saw.recipeBuilder()
+			.inputs(gemExquisite)
+			.outputs(gemFlawless.firstItem * 2)
+			.fluidInputs(cuttingFluid * cuttingFluidAmount)
+			.duration(recipeDuration)
+			.EUt(cuttingRecipeEUt)
+			.buildAndRegister();
+
+		// Cut 1 Flawless into 4 Regular
+		saw.recipeBuilder()
+			.inputs(gemFlawless)
+			.outputs(gemRegular.firstItem * 4)
+			.fluidInputs(cuttingFluid * cuttingFluidAmount)
+			.duration(recipeDuration)
+			.EUt(cuttingRecipeEUt)
+			.buildAndRegister();
+
+		// Remove existing Macerator recipes
+		for entry in [gemExquisite, gemFlawless] as IOreDictEntry[] {
+			val recipe = macerator.findRecipe(8, [entry.firstItem], [null]);
+
+			if (!isNull(recipe)) {
+				recipe.remove();
+			}
+		}
+		
+		// Macerate 1 Exquisite into 8 Dust
+		macerator.recipeBuilder()
+			.inputs(gemExquisite)
+			.outputs([gemDust.firstItem * 8])
+			.duration(120)
+			.EUt(8)
+			.buildAndRegister();
+
+		// Macerate 1 Flawless into 4 Dust
+		macerator.recipeBuilder()
+			.inputs(gemFlawless)
+			.outputs([gemDust.firstItem * 4])
+			.duration(60)
+			.EUt(8)
+			.buildAndRegister();
+
+	}
+}


### PR DESCRIPTION
Both code sections are related to ore processing and don't belong to Endgame.zs at all.

This PR also:
* adds ore dictionary entries for Dense Ores (denseOre*);
* hides exquisite, flawless, flawed and chipped versions of lapis and coal coke;
* fixes ratios of exquisite gems to gem dusts;
* prettifies both scripts to remove duplicate code and increase readability.