### PR TITLE
Make GT Endstone Dust the default variant

### DIFF
--- a/overrides/scripts/Alchemy.zs
+++ b/overrides/scripts/Alchemy.zs
@@ -46,7 +46,7 @@ recipes.addShaped(<dimensionaledibles:nether_cake>, [[<gregtech:meta_item_1:2333
 <dimensionaledibles:nether_cake>.addTooltip(format.darkAqua(format.italic("Refill using Obsidian.")));
 
 //End Cake
-recipes.addShaped(<dimensionaledibles:end_cake>, [[<contenttweaker:endstonedust>,<contenttweaker:endstonedust>,<contenttweaker:endstonedust>], [<minecraft:ender_eye>, <enderio:item_material:70>, <minecraft:ender_eye>],[<gregtech:meta_item_1:12231>,<gregtech:meta_item_1:12231>,<gregtech:meta_item_1:12231>]]);
+recipes.addShaped(<dimensionaledibles:end_cake>, [[<ore:dustEndstone>,<ore:dustEndstone>,<ore:dustEndstone>], [<minecraft:ender_eye>, <enderio:item_material:70>, <minecraft:ender_eye>],[<gregtech:meta_item_1:12231>,<gregtech:meta_item_1:12231>,<gregtech:meta_item_1:12231>]]);
 <dimensionaledibles:end_cake>.addTooltip(format.darkAqua(format.italic("Refill using Eyes of Ender.")));
 
 //Voidworld Cake

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -184,7 +184,7 @@ alloy.recipeBuilder().inputs([<gregtech:meta_item_1:10184>, <minecraft:obsidian>
 alloy.recipeBuilder().inputs([<gregtech:meta_item_1:10184>, <actuallyadditions:item_crystal:3>]).outputs([<enderio:item_alloy_ingot:6>]).duration(240).EUt(16).buildAndRegister();
 alloy.recipeBuilder().inputs([<gregtech:meta_item_1:10184>, <gregtech:meta_item_1:2061>]).outputs([<enderio:item_alloy_ingot>]).duration(120).EUt(16).buildAndRegister();
 alloy.recipeBuilder().inputs([<minecraft:gold_ingot>, <minecraft:soul_sand>]).outputs([<enderio:item_alloy_ingot:7>]).duration(120).EUt(16).buildAndRegister();
-alloy.recipeBuilder().inputs([<enderio:item_alloy_ingot:6>, <contenttweaker:endstonedust>]).outputs([<enderio:item_alloy_ingot:8>]).duration(300).EUt(120).buildAndRegister();
+alloy.recipeBuilder().inputs([<enderio:item_alloy_ingot:6>, <ore:dustEndstone>]).outputs([<enderio:item_alloy_ingot:8>]).duration(300).EUt(120).buildAndRegister();
 alloy.recipeBuilder().inputs([<minecraft:glass>, <gregtech:meta_item_1:2202>]).outputs([<appliedenergistics2:quartz_glass> * 2]).duration(100).EUt(16).buildAndRegister();
 
 //Ender Chest
@@ -380,7 +380,9 @@ macerator.recipeBuilder().inputs([<minecraft:cobblestone>]).outputs([<minecraft:
 macerator.recipeBuilder().inputs([<minecraft:gravel>]).outputs([<minecraft:sand>]).duration(16).EUt(10).buildAndRegister();
 macerator.recipeBuilder().inputs([<minecraft:sand>]).outputs([<contenttweaker:block_dust>]).duration(16).EUt(10).buildAndRegister();
 macerator.recipeBuilder().inputs([<minecraft:netherrack>]).outputs([<gregtech:meta_item_1:2333>]).duration(16).EUt(10).buildAndRegister();
-macerator.recipeBuilder().inputs([<minecraft:end_stone>]).outputs([<contenttweaker:endstonedust>]).duration(16).EUt(10).buildAndRegister();
+
+macerator.findRecipe(8, [<minecraft:end_stone>], [null]).remove();
+macerator.recipeBuilder().inputs([<ore:endstone>.firstItem]).outputs([<ore:dustEndstone>.firstItem]).duration(16).EUt(10).buildAndRegister();
 
 //Copper Furnace
 recipes.remove(<morefurnaces:furnaceblock:5>);

--- a/overrides/scripts/ExtendedCrafting.zs
+++ b/overrides/scripts/ExtendedCrafting.zs
@@ -365,7 +365,7 @@ reactor.recipeBuilder().inputs([<gregtech:meta_item_1:2101>]).fluidInputs([<liqu
 reactor.recipeBuilder().inputs([<gregtech:meta_item_1:2106>]).fluidInputs([<liquid:elementalreduction> * 100]).outputs(<thermalfoundation:material:2053>).EUt(90).duration(160).buildAndRegister();
 
 //Blitz Powder
-reactor.recipeBuilder().inputs(<contenttweaker:endstonedust>).fluidInputs([<liquid:elementalreduction> * 100]).outputs(<thermalfoundation:material:2051>).EUt(90).duration(160).buildAndRegister();
+reactor.recipeBuilder().inputs(<ore:dustEndstone>).fluidInputs([<liquid:elementalreduction> * 100]).outputs(<thermalfoundation:material:2051>).EUt(90).duration(160).buildAndRegister();
 
 //Blizz Powder
 reactor.recipeBuilder().inputs(<minecraft:snow>).fluidInputs([<liquid:elementalreduction> * 100]).outputs(<thermalfoundation:material:2049>).EUt(90).duration(160).buildAndRegister();
@@ -382,8 +382,6 @@ reactor.recipeBuilder().inputs(<minecraft:slime>).fluidInputs([<liquid:titanium>
 <extendedcrafting:storage:6>.displayName = "Block of Endest Stars";
 <extendedcrafting:material:40>.displayName = "Endest Star";
 <extendedcrafting:material:41>.displayName = "Endest Star Nugget";
-
-macerator.findRecipe(8, [<minecraft:end_stone>], [null]).remove();
 
 ///////////////////////// Omnium  ///////////////////////////////
 

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -367,6 +367,11 @@ var dustsDisabled as IItemStack[][IOreDictEntry] = {
 	#itemSawdust
 	<ore:itemSawdust>: [
 		<thermalfoundation:material:800>
+	],
+
+	#dustEndstone
+	<ore:dustEndstone>: [
+		<nuclearcraft:gem_dust:11>
 	]
 
 };
@@ -1912,6 +1917,11 @@ mods.jei.JEI.removeAndHide(<gregtech:meta_item_2:32496>);		//circuit2
 
 //sulfur from thermal to gt sulfur
 recipes.addShapeless(<gregtech:meta_item_1:2065>, [<thermalfoundation:material:771>]);
+
+// Temporary recipe to convert endstone dusts
+recipes.addShapeless(<ore:dustEndstone>.firstItem, [<contenttweaker:endstonedust>]);
+<contenttweaker:endstonedust>.addTooltip(format.red("This item is obsolete and will be removed in the next update."));
+<contenttweaker:endstonedust>.addTooltip(format.red("Please use the GregTech variant of Endstone Dust."));
 
 recipes.addShapeless(<gregtech:meta_item_1:12972>, [<moreplates:neutronium_plate>]);		//neutronium plate exchange
 recipes.addShapeless(<moreplates:neutronium_plate>, [<gregtech:meta_item_1:12972>]);		//neutronium plate exchange


### PR DESCRIPTION
Makes the CraftTweaker variant uncraftable but usable in recipes and adds a tooltip to it.
Adds a shapeless conversion recipe.
Removes the NuclearCraft variant from `<ore:dustEndstone>`.

Closes #365.

![image](https://user-images.githubusercontent.com/22255622/76679407-58100980-6634-11ea-8a9a-3bb54ae9289d.png)
