### PR TITLE
Add unique colors to every ore deposite in Scannable

### DIFF
--- a/overrides/config/scannable.cfg
+++ b/overrides/config/scannable.cfg
@@ -106,12 +106,15 @@ general {
     # key being the ore dictionary name and the value being the hexadecimal
     # RGB value of the color.
     S:oreColors <
+
+    	//Apatite Veins
         //pale blue and rich yellow
         oreApatite=0xa0c9eb
         orePhosphor=0xd1bc00
         oreGravelApatite=0xa0c9eb
         oreGravelPhosphor=0xd1bc00        
         
+        //Bauxite Veins
         //vibrant sky blue
         oreBauxite=0x0095ff
         oreAluminium=0x0095ff
@@ -121,28 +124,38 @@ general {
         oreGravelAluminium=0x0095ff
         oreGravelIlmenite=0x0095ff        
         
+        //Berylium Veins
         //vibrant green
         oreBerylium=0x1ea300
         oreThorium=0x1ea300
         oreEmerald=0x1ea300
         oreGravelBerylium=0x1ea300
         oreGravelThorium=0x1ea300
-        oreGravelEmerald=0x1ea300        
+        oreGravelEmerald=0x1ea300 
+        oreEndstoneBerylium=0x1ea300
+        oreEndstoneThorium=0x1ea300
+        oreEndstoneEmerald=0x1ea300        
         
+        //Lignite/Coal Veins
         //brown + black
         oreLignite=0xad8657
         oreCoal=0x999999
         oreGravelLignite=0xad8657
         oreGravelCoal=0x999999        
         
+        //Copper Veins
         //vibrant orange
         oreCopper=0xff7b00
         oreChalcopyrite=0xff7b00
         oreIron=0xff7b00
         oreGravelCopper=0xff7b00
         oreGravelChalcopyrite=0xff7b00
-        oreGravelIron=0xff7b00        
+        oreGravelIron=0xff7b00  
+        oreNetherrackCopper=0xff7b00
+        oreNetherrackChalcopyrite=0xff7b00
+        oreNetherrackIron=0xff7b00              
         
+        //Diamond Veins
         //vibrant cyan
         oreGraphite=0x00ffff
         oreDiamond=0x00ffff
@@ -150,6 +163,7 @@ general {
         oreGravelGraphite=0x00ffff
         oreGravelDiamond=0x00ffff        
         
+        //Galena Veins
         //silver and purple
         oreGalena=0x8d44db
         oreSilver=0xedfffe
@@ -158,6 +172,7 @@ general {
         oreGravelSilver=0xedfffe
         oreGravelLead=0x8d44db        
         
+        //Iron Veins
         //salmon pink
         oreYellowLimonite=0xffabab
         oreBrownLimonite=0xffabab
@@ -166,8 +181,13 @@ general {
         oreGravelYellowLimonite=0xffabab
         oreGravelBrownLimonite=0xffabab
         oreGravelBandedIron=0xffabab
-        oreGravelMalachite=0xffabab        
+        oreGravelMalachite=0xffabab
+        oreNetherrackYellowLimonite=0xffabab
+        oreNetherrackBrownLimonite=0xffabab
+        oreNetherrackBandedIron=0xffabab
+        oreNetherrackMalachite=0xffabab                
         
+        //Lapis Veins
         //vibrant blue
         oreLazurite=0x0000ff
         oreSodalite=0x0000ff
@@ -176,8 +196,13 @@ general {
         oreGravelLazurite=0x0000ff
         oreGravelSodalite=0x0000ff
         oreGravelCalcite=0x0000ff
-        oreGravelLapis=0x0000ff        
+        oreGravelLapis=0x0000ff   
+        oreEndstoneLazurite=0x0000ff
+        oreEndstoneSodalite=0x0000ff
+        oreEndstoneCalcite=0x0000ff
+        oreEndstoneLapis=0x0000ff             
         
+        //Magnetite Veins
         //vibrant yellow
         oreMagnetite=0xffff00
         //oreIron= defined elsewhere
@@ -185,8 +210,12 @@ general {
         oreGold=0xffff00
         oreGravelMagnetite=0xffff00
         oreGravelVanadiumMagnetite=0xffff00
-        oreGravelGold=0xffff00        
+        oreGravelGold=0xffff00
+        oreNetherrackMagnetite=0xffff00
+        oreNetherrackVanadiumMagnetite=0xffff00
+        oreNetherrackGold=0xffff00                
         
+        //Manganese Veins
         //vibrant pink
         oreGrossular=0xff007b
         oreSpessartine=0xff007b
@@ -195,16 +224,25 @@ general {
         oreGravelGrossular=0xff007b
         oreGravelSpessartine=0xff007b
         oreGravelPyrolusite=0xff007b
-        oreGravelTantalite=0xff007b        
+        oreGravelTantalite=0xff007b 
+        oreEndstoneGrossular=0xff007b
+        oreEndstoneSpessartine=0xff007b
+        oreEndstonePyrolusite=0xff007b
+        oreEndstoneTantalite=0xff007b               
         
+        //Molybdenite Veins
         //white and purple
         oreWulfenite=0xffffff
         oreMolybdenite=0x6a3cb5
         orePowellite=0x6a3cb5
         oreGravelWulfenite=0xffffff
         oreGravelMolybdenite=0x6a3cb5
-        oreGravelPowellite=0x6a3cb5        
+        oreGravelPowellite=0x6a3cb5   
+        oreEndstoneWulfenite=0xffffff
+        oreEndstoneMolybdenite=0x6a3cb5
+        oreEndstonePowellite=0x6a3cb5             
         
+        //Monazite Veins
         //vibrant magenta
         oreBastnasite=0xff00ff
         oreMonazite=0xff00ff
@@ -213,6 +251,7 @@ general {
         oreGravelMonazite=0xff00ff
         oreGravelNeodymium=0xff00ff        
         
+        //Nickel Veins
         //vibrant teal
         oreGarnierite=0x00ff99
         orePentlandite=0x00ff99
@@ -221,12 +260,22 @@ general {
         oreGravelGarnierite=0x00ff99
         oreGravelPentlandite=0x00ff99
         oreGravelNickel=0x00ff99
-        oreGravelCobaltite=0x00ff99        
+        oreGravelCobaltite=0x00ff99 
+        oreEndstoneGarnierite=0x00ff99
+        oreEndstonePentlandite=0x00ff99
+        oreEndstoneNickel=0x00ff99
+        oreEndstoneCobaltite=0x00ff99
+        oreNetherrackGarnierite=0x00ff99
+        oreNetherrackPentlandite=0x00ff99
+        oreNetherrackNickel=0x00ff99
+        oreNetherrackCobaltite=0x00ff99                       
         
+        //Oilsands Veins
         //gray
         oreOilsands=0x999999
         oreGravelOilsands=0x999999        
         
+        //Olivine Veins
         //olive green
         oreBentonite=0x648047
         oreMagnesite=0x648047
@@ -235,8 +284,13 @@ general {
         oreGravelBentonite=0x648047
         oreGravelMagnesite=0x648047
         oreGravelOlivine=0x648047
-        oreGravelGlauconite=0x648047        
+        oreGravelGlauconite=0x648047
+        oreEndstoneBentonite=0x648047
+        oreEndstoneMagnesite=0x648047
+        oreEndstoneOlivine=0x648047
+        oreEndstoneGlauconite=0x648047                
         
+        //Pitchblende Veins
         //vibrant lime
         orePitchblende=0xbbff00
         oreUranium=0xbbff00
@@ -245,13 +299,17 @@ general {
         oreGravelUranium=0xbbff00
         oreGravelUraninite=0xbbff00        
         
+        //Platinum Veins
         //baby pink and baby blue
         orePlatinum=0x6ec2ff
         orePalladium=0xff879b
         //oreIlmenite= defined elsewhere
         oreGravelPlatinum=0x6ec2ff
         oreGravelPalladium=0xff879b
+        oreEndstonePlatinum=0x6ec2ff
+        oreEndstonePalladium=0xff879b        
 
+        //Quartz Veins
         //white-mint green
         oreQuartzite=0xc2ffd1
         oreBarite=0xc2ffd1
@@ -260,16 +318,22 @@ general {
         oreGravelQuartzite=0xc2ffd1
         oreGravelBarite=0xc2ffd1
         oreGravelNetherQuartz=0xc2ffd1
-        oreGravelCertusQuartz=0xc2ffd1        
+        oreGravelCertusQuartz=0xc2ffd1  
+        oreNetherrackNetherQuartz=0xc2ffd1              
         
+        //Redstone Veins
         //vibrant red
         oreRedstone=0xff0000
         oreRuby=0xff0000
         oreCinnabar=0xff0000
         oreGravelRedstone=0xff0000
         oreGravelRuby=0xff0000
-        oreGravelCinnabar=0xff0000        
+        oreGravelCinnabar=0xff0000
+        oreNetherrackRedstone=0xff0000
+        oreNetherrackRuby=0xff0000
+        oreNetherrackCinnabar=0xff0000                
         
+        //Salt Veins
         //white and pink
         oreSalt=0xffffff
         oreRockSalt=0xffffff
@@ -281,6 +345,7 @@ general {
         oreGravelLepidolite=0xff007b
         oreGravelSpodumene=0xff007b
 
+        //Sapphire Veins
         //purple and red
         oreAlmandine=0xa30000
         orePyrope=0xa30000
@@ -291,6 +356,7 @@ general {
         oreGravelSaphire=0xa55cff
         oreGravelGreenSapphire=0xa55cff        
         
+        //Soapstone Veins
         //pale green
         oreSoapstone=0x97e693
         oreTalc=0x97e693
@@ -300,27 +366,36 @@ general {
         oreGravelTalc=0x97e693
         oreGravelGlauconite=0x97e693
 
+        //Tetrahedrite Veins
         //red and orange
         oreTetrahedrite=0xff7878
         //oreCopper= defined elsewhere
         oreStibnite=0xff7878
         oreGravelTetrahedrite=0xff7878
-        oreGravelStibnite=0xff7878        
+        oreGravelStibnite=0xff7878
+        oreNetherrackTetrahedrite=0xff7878
+        oreNetherrackStibnite=0xff7878                
         
+        //Tin Veins
         //light gray
         oreTin=0xbcdce6
         oreCassiterite=0xbcdce6
         oreGravelTin=0xbcdce6
         oreGravelCassiterite=0xbcdce6        
         
+        //Tungstate Veins
         //vibrant violet
         oreScheelite=0x7300ff
         oreTungstate=0x7300ff
         oreLithium=0x7300ff
         oreGravelScheelite=0x7300ff
         oreGravelTungstate=0x7300ff
-        oreGravelLithium=0x7300ff        
+        oreGravelLithium=0x7300ff
+        oreEndstoneScheelite=0x7300ff
+        oreEndstoneTungstate=0x7300ff
+        oreEndstoneLithium=0x7300ff                
         
+        //Zinc Veins
         //white and blue
         oreZinc=0xffffff
         orePyrite=0xffffff
@@ -328,8 +403,23 @@ general {
         oreGravelZinc=0xffffff
         oreGravelPyrite=0xffffff
         oreGravelSphalerite=0x00a2ff
+        oreNetherrackSphalerite=0x00a2ff 
+        oreNetherrackPyrite=0xffffff               
 
-        //Nether Sulfur Veins        
+        //Nether Specific
+        //Nether Sulfur Veins, Bright Yellow
+        oreNetherrackSulfur=0xfcd703
+
+
+        //Moon Specific
+        //Rutile
+        oreRutile=0xfc0362
+
+        //Dilithium
+        oreDilithium=0x570034
+
+        //Black Quartz
+        oreQuartzBlack=0x000108
         
         
         glowstone=0xE9E68E
@@ -347,11 +437,7 @@ general {
         oreApatite
         orePhosphor
         oreGravelApatite
-        oreGravelPhosphor                
-
-        //Lapis Veins
-        oreSodalite
-		oreGravelSodalite        
+        oreGravelPhosphor                       
 		
 		//Copper Veins
 		oreChalcopyrite
@@ -373,7 +459,12 @@ general {
 		oreGravelYellowLimonite
 		oreGravelBrownLimonite 
 		oreGravelBandedIron
-		oreGravelMalachite		
+		oreGravelMalachite
+
+        //Lapis Veins
+        oreSodalite
+		oreGravelSodalite
+		oreEndstoneSodalite 				
 
 		//Lignite Coal Veins
 		oreLignite
@@ -453,7 +544,32 @@ general {
 		oreSphalerite
 		oreGravelZinc
 		oreGravelPyrite
-		oreGravelSphalerite		
+		oreGravelSphalerite
+
+		//Nether Veins
+		//Sulfur
+        oreNetherrackSphalerite 
+        oreNetherrackPyrite	
+        oreNetherrackSulfur	
+
+        //Nether Quartz
+        oreNetherrackNetherQuartz
+
+        //Magnetite
+        oreNetherrackMagnetite
+        oreNetherrackVanadiumMagnetite
+        oreNetherrackGold
+        oreNetherrackIron 
+
+        //Iron Veins
+        oreNetherrackYellowLimonite
+        oreNetherrackBrownLimonite
+        oreNetherrackBandedIron
+        oreNetherrackMalachite   
+
+        //Moon Veins
+        oreDilithium               
+
      >
 
     # Ore dictionary names of ores considered 'rare', requiring the rare ore scanner module.

--- a/overrides/config/scannable.cfg
+++ b/overrides/config/scannable.cfg
@@ -109,106 +109,166 @@ general {
         //pale blue and rich yellow
         oreApatite=0xa0c9eb
         orePhosphor=0xd1bc00
+        oreGravelApatite=0xa0c9eb
+        oreGravelPhosphor=0xd1bc00        
         
         //vibrant sky blue
         oreBauxite=0x0095ff
         oreAluminium=0x0095ff
         //oreTin= defined elsewhere
         oreIlmenite=0x0095ff
+        oreGravelBauxite=0x0095ff
+        oreGravelAluminium=0x0095ff
+        oreGravelIlmenite=0x0095ff        
         
         //vibrant green
         oreBerylium=0x1ea300
         oreThorium=0x1ea300
         oreEmerald=0x1ea300
+        oreGravelBerylium=0x1ea300
+        oreGravelThorium=0x1ea300
+        oreGravelEmerald=0x1ea300        
         
         //brown + black
         oreLignite=0xad8657
         oreCoal=0x999999
+        oreGravelLignite=0xad8657
+        oreGravelCoal=0x999999        
         
         //vibrant orange
         oreCopper=0xff7b00
         oreChalcopyrite=0xff7b00
         oreIron=0xff7b00
+        oreGravelCopper=0xff7b00
+        oreGravelChalcopyrite=0xff7b00
+        oreGravelIron=0xff7b00        
         
         //vibrant cyan
         oreGraphite=0x00ffff
         oreDiamond=0x00ffff
         //oreCoal= defined elsewhere
+        oreGravelGraphite=0x00ffff
+        oreGravelDiamond=0x00ffff        
         
         //silver and purple
         oreGalena=0x8d44db
         oreSilver=0xedfffe
         oreLead=0x8d44db
+        oreGravelGalena=0x8d44db
+        oreGravelSilver=0xedfffe
+        oreGravelLead=0x8d44db        
         
         //salmon pink
         oreYellowLimonite=0xffabab
         oreBrownLimonite=0xffabab
         oreBandedIron=0xffabab
         oreMalachite=0xffabab
+        oreGravelYellowLimonite=0xffabab
+        oreGravelBrownLimonite=0xffabab
+        oreGravelBandedIron=0xffabab
+        oreGravelMalachite=0xffabab        
         
         //vibrant blue
         oreLazurite=0x0000ff
         oreSodalite=0x0000ff
         oreCalcite=0x0000ff
         oreLapis=0x0000ff
+        oreGravelLazurite=0x0000ff
+        oreGravelSodalite=0x0000ff
+        oreGravelCalcite=0x0000ff
+        oreGravelLapis=0x0000ff        
         
         //vibrant yellow
         oreMagnetite=0xffff00
         //oreIron= defined elsewhere
         oreVanadiumMagnetite=0xffff00
         oreGold=0xffff00
+        oreGravelMagnetite=0xffff00
+        oreGravelVanadiumMagnetite=0xffff00
+        oreGravelGold=0xffff00        
         
         //vibrant pink
         oreGrossular=0xff007b
         oreSpessartine=0xff007b
         orePyrolusite=0xff007b
         oreTantalite=0xff007b
+        oreGravelGrossular=0xff007b
+        oreGravelSpessartine=0xff007b
+        oreGravelPyrolusite=0xff007b
+        oreGravelTantalite=0xff007b        
         
         //white and purple
         oreWulfenite=0xffffff
         oreMolybdenite=0x6a3cb5
         orePowellite=0x6a3cb5
+        oreGravelWulfenite=0xffffff
+        oreGravelMolybdenite=0x6a3cb5
+        oreGravelPowellite=0x6a3cb5        
         
         //vibrant magenta
         oreBastnasite=0xff00ff
         oreMonazite=0xff00ff
         oreNeodymium=0xff00ff
+        oreGravelBastnasite=0xff00ff
+        oreGravelMonazite=0xff00ff
+        oreGravelNeodymium=0xff00ff        
         
         //vibrant teal
         oreGarnierite=0x00ff99
         orePentlandite=0x00ff99
         oreNickel=0x00ff99
         oreCobaltite=0x00ff99
+        oreGravelGarnierite=0x00ff99
+        oreGravelPentlandite=0x00ff99
+        oreGravelNickel=0x00ff99
+        oreGravelCobaltite=0x00ff99        
         
         //gray
         oreOilsands=0x999999
+        oreGravelOilsands=0x999999        
         
         //olive green
         oreBentonite=0x648047
         oreMagnesite=0x648047
         oreOlivine=0x648047
         oreGlauconite=0x648047
+        oreGravelBentonite=0x648047
+        oreGravelMagnesite=0x648047
+        oreGravelOlivine=0x648047
+        oreGravelGlauconite=0x648047        
         
         //vibrant lime
         orePitchblende=0xbbff00
         oreUranium=0xbbff00
         oreUraninite=0xbbff00
+        oreGravelPitchblende=0xbbff00
+        oreGravelUranium=0xbbff00
+        oreGravelUraninite=0xbbff00        
         
         //baby pink and baby blue
         orePlatinum=0x6ec2ff
         orePalladium=0xff879b
         //oreIlmenite= defined elsewhere
-        
+        oreGravelPlatinum=0x6ec2ff
+        oreGravelPalladium=0xff879b
+
         //white-mint green
         oreQuartzite=0xc2ffd1
         oreBarite=0xc2ffd1
         oreNetherQuartz=0xc2ffd1
         oreCertusQuartz=0xc2ffd1
+        oreGravelQuartzite=0xc2ffd1
+        oreGravelBarite=0xc2ffd1
+        oreGravelNetherQuartz=0xc2ffd1
+        oreGravelCertusQuartz=0xc2ffd1        
         
         //vibrant red
         oreRedstone=0xff0000
         oreRuby=0xff0000
         oreCinnabar=0xff0000
+        oreGravelRedstone=0xff0000
+        oreGravelRuby=0xff0000
+        oreGravelCinnabar=0xff0000        
         
         //white and pink
         oreSalt=0xffffff
@@ -216,89 +276,184 @@ general {
         oreLepidolite=0xff007b
         oreSpodumene=0xff007b
         //oreTin= defined elsewhere
-        
+        oreGravelSalt=0xffffff
+        oreGravelRockSalt=0xffffff
+        oreGravelLepidolite=0xff007b
+        oreGravelSpodumene=0xff007b
+
         //purple and red
         oreAlmandine=0xa30000
         orePyrope=0xa30000
         oreSaphire=0xa55cff
         oreGreenSapphire=0xa55cff
+        oreGravelAlmandine=0xa30000
+        oreGravelPyrope=0xa30000
+        oreGravelSaphire=0xa55cff
+        oreGravelGreenSapphire=0xa55cff        
         
         //pale green
         oreSoapstone=0x97e693
         oreTalc=0x97e693
         oreGlauconite=0x97e693
         //orePentlandite= defined elsewhere
-        
+        oreGravelSoapstone=0x97e693
+        oreGravelTalc=0x97e693
+        oreGravelGlauconite=0x97e693
+
         //red and orange
         oreTetrahedrite=0xff7878
         //oreCopper= defined elsewhere
         oreStibnite=0xff7878
+        oreGravelTetrahedrite=0xff7878
+        oreGravelStibnite=0xff7878        
         
         //light gray
         oreTin=0xbcdce6
         oreCassiterite=0xbcdce6
+        oreGravelTin=0xbcdce6
+        oreGravelCassiterite=0xbcdce6        
         
         //vibrant violet
         oreScheelite=0x7300ff
         oreTungstate=0x7300ff
         oreLithium=0x7300ff
+        oreGravelScheelite=0x7300ff
+        oreGravelTungstate=0x7300ff
+        oreGravelLithium=0x7300ff        
         
         //white and blue
         oreZinc=0xffffff
         orePyrite=0xffffff
         oreSphalerite=0x00a2ff
+        oreGravelZinc=0xffffff
+        oreGravelPyrite=0xffffff
+        oreGravelSphalerite=0x00a2ff
+
+        //Nether Sulfur Veins        
         
         
-        
-        
-        //oreCoal=0x433E3B
-        //oreIron=0xA17951
-        //oreGold=0xF4F71F
-        //oreLapis=0x4863F0
-        //oreDiamond=0x48E2F0
-        //oreRedstone=0xE61E1E
-        //oreEmerald=0x12BA16
-        //oreQuartz=0xB3D9D2
         glowstone=0xE9E68E
-        //oreCopper=0xE4A020
-        //oreLead=0x8187C3
-        //oreMithril=0x97D5FE
-        //oreNickel=0xD0D3AC
-        //orePlatinum=0x7AC0FD
-        //oreSilver=0xE8F2FB
-        //oreTin=0xCCE4FE
-        //oreAluminum=0xCBE4E2
-        //oreAluminium=0xCBE4E2
-        //orePlutonium=0x9DE054
-        //oreUranium=0x9DE054
-        //oreYellorium=0xD8E054
-        //oreArdite=0xB77E11
-        //oreCobalt=0x413BB8
-        //oreCinnabar=0xF5DA25
-        //oreInfusedAir=0xF7E677
-        //oreInfusedFire=0xDC7248
-        //oreInfusedWater=0x9595D5
-        //oreInfusedEarth=0x49B45A
-        //oreInfusedOrder=0x9FF2DE
-        //oreInfusedEntropy=0x545476
+
      >
 
     # Ore dictionary entries considered common ores, requiring the common ore scanner module.
     # Use this to mark ores as common, as opposed to rare (see oresRare).
     S:oresCommon <
-        oreCoal
-        oreIron
-        oreRedstone
+        
+
         glowstone
-        oreCopper
-        oreTin
-        oreLead
-		oreBandedIron
-		oreCassiterite
-		oreMalachite
+
+        //Apatite Veins
+        oreApatite
+        orePhosphor
+        oreGravelApatite
+        oreGravelPhosphor                
+
+        //Lapis Veins
+        oreSodalite
+		oreGravelSodalite        
+		
+		//Copper Veins
 		oreChalcopyrite
+		oreGravelChalcopyrite
+      
+       	//Galena Veins
+        oreGalena
+        oreSilver
+        oreLead
+        oreGravelGalena
+        oreGravelSilver
+        oreGravelLead        
+		
+		//Iron Veins
 		oreYellowLimonite
-		oreBrownLimonite
+		oreBrownLimonite 
+		oreBandedIron
+		oreMalachite
+		oreGravelYellowLimonite
+		oreGravelBrownLimonite 
+		oreGravelBandedIron
+		oreGravelMalachite		
+
+		//Lignite Coal Veins
+		oreLignite
+		oreGravelLignite				
+
+		//Magnetite Veins
+        oreMagnetite
+        oreIron
+        oreVanadiumMagnetite
+        oreGold		
+        oreGravelMagnetite
+        oreGravelIron
+        oreGravelVanadiumMagnetite
+        oreGravelGold	        
+
+		//Oilsands Vein
+		oreOilsands
+		oreCoal
+		oreGravelOilsands
+		oreGravelCoal		
+
+		//Quartz Veins
+        oreQuartzite
+        oreBarite
+        oreNetherQuartz
+        oreCertusQuartz		
+        oreGravelQuartzite
+        oreGravelBarite
+        oreGravelNetherQuartz
+        oreGravelCertusQuartz	        
+
+		//Redstone Veins
+        oreRedstone
+        oreRuby
+        oreCinnabar	
+        oreGravelRedstone
+        oreGravelRuby
+        oreGravelCinnabar	        	
+
+		//Salt Veins
+        oreSalt
+        oreRockSalt
+        oreLepidolite
+        oreSpodumene	
+        oreGravelSalt
+        oreGravelRockSalt
+        oreGravelLepidolite
+        oreGravelSpodumene        
+
+		//Soapstone Veins
+		oreSoapstone
+		oreGlauconite
+		orePentlandite
+		oreTalc
+		oreGravelSoapstone
+		oreGravelGlauconite
+		oreGravelPentlandite
+		oreGravelTalc		
+
+		//Tetrahedrite Veins
+		oreTetrahedrite
+		oreStibnite
+		oreCopper
+		oreGravelTetrahedrite
+		oreGravelStibnite
+		oreGravelCopper		
+
+        //Tin Veins
+        oreTin
+		oreCassiterite 
+        oreGravelTin
+		oreGravelCassiterite 		 		
+
+		//Zinc Veins
+		oreZinc
+		orePyrite
+		oreSphalerite
+		oreGravelZinc
+		oreGravelPyrite
+		oreGravelSphalerite		
      >
 
     # Ore dictionary names of ores considered 'rare', requiring the rare ore scanner module.
@@ -307,6 +462,22 @@ general {
     # to make missing entries less likely be a problem). Use this to add rare
     # ores that do follow this pattern.
     S:oresRare <
+
+    	//Included in this by omission from above are
+    	//Tungstate Veins
+    	//Sapphire Veins
+    	//Platinum Veins
+    	//Olivine Veins
+    	//Pitchblende Veins
+    	//Monazite Veins
+    	//Molybdenum Veins
+    	//Manganese Veins
+    	//Lapis Veins (Minus the Sodalite)
+    	//Diamond Veins
+    	//Beryllium Veins
+    	//Bauxite Veins (Minus the tin)
+    	//To see all ores included in these veins, please see the gtce config worldgen file
+
      >
 
     # Block states considered common ores, requiring the common ore scanner module.

--- a/overrides/config/scannable.cfg
+++ b/overrides/config/scannable.cfg
@@ -464,7 +464,7 @@ general {
         //Lapis Veins
         oreSodalite
 		oreGravelSodalite
-		oreEndstoneSodalite 				
+		 				
 
 		//Lignite Coal Veins
 		oreLignite
@@ -568,7 +568,21 @@ general {
         oreNetherrackMalachite   
 
         //Moon Veins
-        oreDilithium               
+        oreDilithium
+
+        //End Veins
+        //Olivine
+        oreEndstoneBentonite
+        oreEndstoneMagnesite
+        oreEndstoneOlivine
+        oreEndstoneGlauconite 
+
+        //Lapis Veins
+        oreEndstoneLazurite
+        oreEndstoneSodalite
+        oreEndstoneCalcite
+        oreEndstoneLapis                 
+
 
      >
 

--- a/overrides/config/scannable.cfg
+++ b/overrides/config/scannable.cfg
@@ -106,36 +106,181 @@ general {
     # key being the ore dictionary name and the value being the hexadecimal
     # RGB value of the color.
     S:oreColors <
-        oreCoal=0x433E3B
-        oreIron=0xA17951
-        oreGold=0xF4F71F
-        oreLapis=0x4863F0
-        oreDiamond=0x48E2F0
-        oreRedstone=0xE61E1E
-        oreEmerald=0x12BA16
-        oreQuartz=0xB3D9D2
+        //pale blue and rich yellow
+        oreApatite=0xa0c9eb
+        orePhosphor=0xd1bc00
+        
+        //vibrant sky blue
+        oreBauxite=0x0095ff
+        oreAluminium=0x0095ff
+        //oreTin= defined elsewhere
+        oreIlmenite=0x0095ff
+        
+        //vibrant green
+        oreBerylium=0x1ea300
+        oreThorium=0x1ea300
+        oreEmerald=0x1ea300
+        
+        //brown + black
+        oreLignite=0xad8657
+        oreCoal=0x999999
+        
+        //vibrant orange
+        oreCopper=0xff7b00
+        oreChalcopyrite=0xff7b00
+        oreIron=0xff7b00
+        
+        //vibrant cyan
+        oreGraphite=0x00ffff
+        oreDiamond=0x00ffff
+        //oreCoal= defined elsewhere
+        
+        //silver and purple
+        oreGalena=0x8d44db
+        oreSilver=0xedfffe
+        oreLead=0x8d44db
+        
+        //salmon pink
+        oreYellowLimonite=0xffabab
+        oreBrownLimonite=0xffabab
+        oreBandedIron=0xffabab
+        oreMalachite=0xffabab
+        
+        //vibrant blue
+        oreLazurite=0x0000ff
+        oreSodalite=0x0000ff
+        oreCalcite=0x0000ff
+        oreLapis=0x0000ff
+        
+        //vibrant yellow
+        oreMagnetite=0xffff00
+        //oreIron= defined elsewhere
+        oreVanadiumMagnetite=0xffff00
+        oreGold=0xffff00
+        
+        //vibrant pink
+        oreGrossular=0xff007b
+        oreSpessartine=0xff007b
+        orePyrolusite=0xff007b
+        oreTantalite=0xff007b
+        
+        //white and purple
+        oreWulfenite=0xffffff
+        oreMolybdenite=0x6a3cb5
+        orePowellite=0x6a3cb5
+        
+        //vibrant magenta
+        oreBastnasite=0xff00ff
+        oreMonazite=0xff00ff
+        oreNeodymium=0xff00ff
+        
+        //vibrant teal
+        oreGarnierite=0x00ff99
+        orePentlandite=0x00ff99
+        oreNickel=0x00ff99
+        oreCobaltite=0x00ff99
+        
+        //gray
+        oreOilsands=0x999999
+        
+        //olive green
+        oreBentonite=0x648047
+        oreMagnesite=0x648047
+        oreOlivine=0x648047
+        oreGlauconite=0x648047
+        
+        //vibrant lime
+        orePitchblende=0xbbff00
+        oreUranium=0xbbff00
+        oreUraninite=0xbbff00
+        
+        //baby pink and baby blue
+        orePlatinum=0x6ec2ff
+        orePalladium=0xff879b
+        //oreIlmenite= defined elsewhere
+        
+        //white-mint green
+        oreQuartzite=0xc2ffd1
+        oreBarite=0xc2ffd1
+        oreNetherQuartz=0xc2ffd1
+        oreCertusQuartz=0xc2ffd1
+        
+        //vibrant red
+        oreRedstone=0xff0000
+        oreRuby=0xff0000
+        oreCinnabar=0xff0000
+        
+        //white and pink
+        oreSalt=0xffffff
+        oreRockSalt=0xffffff
+        oreLepidolite=0xff007b
+        oreSpodumene=0xff007b
+        //oreTin= defined elsewhere
+        
+        //purple and red
+        oreAlmandine=0xa30000
+        orePyrope=0xa30000
+        oreSaphire=0xa55cff
+        oreGreenSapphire=0xa55cff
+        
+        //pale green
+        oreSoapstone=0x97e693
+        oreTalc=0x97e693
+        oreGlauconite=0x97e693
+        //orePentlandite= defined elsewhere
+        
+        //red and orange
+        oreTetrahedrite=0xff7878
+        //oreCopper= defined elsewhere
+        oreStibnite=0xff7878
+        
+        //light gray
+        oreTin=0xbcdce6
+        oreCassiterite=0xbcdce6
+        
+        //vibrant violet
+        oreScheelite=0x7300ff
+        oreTungstate=0x7300ff
+        oreLithium=0x7300ff
+        
+        //white and blue
+        oreZinc=0xffffff
+        orePyrite=0xffffff
+        oreSphalerite=0x00a2ff
+        
+        
+        
+        
+        //oreCoal=0x433E3B
+        //oreIron=0xA17951
+        //oreGold=0xF4F71F
+        //oreLapis=0x4863F0
+        //oreDiamond=0x48E2F0
+        //oreRedstone=0xE61E1E
+        //oreEmerald=0x12BA16
+        //oreQuartz=0xB3D9D2
         glowstone=0xE9E68E
-        oreCopper=0xE4A020
-        oreLead=0x8187C3
-        oreMithril=0x97D5FE
-        oreNickel=0xD0D3AC
-        orePlatinum=0x7AC0FD
-        oreSilver=0xE8F2FB
-        oreTin=0xCCE4FE
-        oreAluminum=0xCBE4E2
-        oreAluminium=0xCBE4E2
-        orePlutonium=0x9DE054
-        oreUranium=0x9DE054
-        oreYellorium=0xD8E054
-        oreArdite=0xB77E11
-        oreCobalt=0x413BB8
-        oreCinnabar=0xF5DA25
-        oreInfusedAir=0xF7E677
-        oreInfusedFire=0xDC7248
-        oreInfusedWater=0x9595D5
-        oreInfusedEarth=0x49B45A
-        oreInfusedOrder=0x9FF2DE
-        oreInfusedEntropy=0x545476
+        //oreCopper=0xE4A020
+        //oreLead=0x8187C3
+        //oreMithril=0x97D5FE
+        //oreNickel=0xD0D3AC
+        //orePlatinum=0x7AC0FD
+        //oreSilver=0xE8F2FB
+        //oreTin=0xCCE4FE
+        //oreAluminum=0xCBE4E2
+        //oreAluminium=0xCBE4E2
+        //orePlutonium=0x9DE054
+        //oreUranium=0x9DE054
+        //oreYellorium=0xD8E054
+        //oreArdite=0xB77E11
+        //oreCobalt=0x413BB8
+        //oreCinnabar=0xF5DA25
+        //oreInfusedAir=0xF7E677
+        //oreInfusedFire=0xDC7248
+        //oreInfusedWater=0x9595D5
+        //oreInfusedEarth=0x49B45A
+        //oreInfusedOrder=0x9FF2DE
+        //oreInfusedEntropy=0x545476
      >
 
     # Ore dictionary entries considered common ores, requiring the common ore scanner module.
@@ -148,9 +293,12 @@ general {
         oreCopper
         oreTin
         oreLead
-        oreAluminum
-        oreAluminium
-        oreCinnabar
+		oreBandedIron
+		oreCassiterite
+		oreMalachite
+		oreChalcopyrite
+		oreYellowLimonite
+		oreBrownLimonite
      >
 
     # Ore dictionary names of ores considered 'rare', requiring the rare ore scanner module.

--- a/overrides/config/scannable.cfg
+++ b/overrides/config/scannable.cfg
@@ -107,13 +107,13 @@ general {
     # RGB value of the color.
     S:oreColors <
 
-    	//Apatite Veins
+        //Apatite Veins
         //pale blue and rich yellow
         oreApatite=0xa0c9eb
         orePhosphor=0xd1bc00
         oreGravelApatite=0xa0c9eb
-        oreGravelPhosphor=0xd1bc00        
-        
+        oreGravelPhosphor=0xd1bc00
+
         //Bauxite Veins
         //vibrant sky blue
         oreBauxite=0x0095ff
@@ -122,8 +122,8 @@ general {
         oreIlmenite=0x0095ff
         oreGravelBauxite=0x0095ff
         oreGravelAluminium=0x0095ff
-        oreGravelIlmenite=0x0095ff        
-        
+        oreGravelIlmenite=0x0095ff
+
         //Berylium Veins
         //vibrant green
         oreBerylium=0x1ea300
@@ -131,18 +131,18 @@ general {
         oreEmerald=0x1ea300
         oreGravelBerylium=0x1ea300
         oreGravelThorium=0x1ea300
-        oreGravelEmerald=0x1ea300 
+        oreGravelEmerald=0x1ea300
         oreEndstoneBerylium=0x1ea300
         oreEndstoneThorium=0x1ea300
-        oreEndstoneEmerald=0x1ea300        
-        
+        oreEndstoneEmerald=0x1ea300
+
         //Lignite/Coal Veins
         //brown + black
         oreLignite=0xad8657
         oreCoal=0x999999
         oreGravelLignite=0xad8657
-        oreGravelCoal=0x999999        
-        
+        oreGravelCoal=0x999999
+
         //Copper Veins
         //vibrant orange
         oreCopper=0xff7b00
@@ -150,19 +150,19 @@ general {
         oreIron=0xff7b00
         oreGravelCopper=0xff7b00
         oreGravelChalcopyrite=0xff7b00
-        oreGravelIron=0xff7b00  
+        oreGravelIron=0xff7b00
         oreNetherrackCopper=0xff7b00
         oreNetherrackChalcopyrite=0xff7b00
-        oreNetherrackIron=0xff7b00              
-        
+        oreNetherrackIron=0xff7b00
+
         //Diamond Veins
         //vibrant cyan
         oreGraphite=0x00ffff
         oreDiamond=0x00ffff
         //oreCoal= defined elsewhere
         oreGravelGraphite=0x00ffff
-        oreGravelDiamond=0x00ffff        
-        
+        oreGravelDiamond=0x00ffff
+
         //Galena Veins
         //silver and purple
         oreGalena=0x8d44db
@@ -170,8 +170,8 @@ general {
         oreLead=0x8d44db
         oreGravelGalena=0x8d44db
         oreGravelSilver=0xedfffe
-        oreGravelLead=0x8d44db        
-        
+        oreGravelLead=0x8d44db
+
         //Iron Veins
         //salmon pink
         oreYellowLimonite=0xffabab
@@ -185,8 +185,8 @@ general {
         oreNetherrackYellowLimonite=0xffabab
         oreNetherrackBrownLimonite=0xffabab
         oreNetherrackBandedIron=0xffabab
-        oreNetherrackMalachite=0xffabab                
-        
+        oreNetherrackMalachite=0xffabab
+
         //Lapis Veins
         //vibrant blue
         oreLazurite=0x0000ff
@@ -196,12 +196,12 @@ general {
         oreGravelLazurite=0x0000ff
         oreGravelSodalite=0x0000ff
         oreGravelCalcite=0x0000ff
-        oreGravelLapis=0x0000ff   
+        oreGravelLapis=0x0000ff
         oreEndstoneLazurite=0x0000ff
         oreEndstoneSodalite=0x0000ff
         oreEndstoneCalcite=0x0000ff
-        oreEndstoneLapis=0x0000ff             
-        
+        oreEndstoneLapis=0x0000ff
+
         //Magnetite Veins
         //vibrant yellow
         oreMagnetite=0xffff00
@@ -213,8 +213,8 @@ general {
         oreGravelGold=0xffff00
         oreNetherrackMagnetite=0xffff00
         oreNetherrackVanadiumMagnetite=0xffff00
-        oreNetherrackGold=0xffff00                
-        
+        oreNetherrackGold=0xffff00
+
         //Manganese Veins
         //vibrant pink
         oreGrossular=0xff007b
@@ -224,12 +224,12 @@ general {
         oreGravelGrossular=0xff007b
         oreGravelSpessartine=0xff007b
         oreGravelPyrolusite=0xff007b
-        oreGravelTantalite=0xff007b 
+        oreGravelTantalite=0xff007b
         oreEndstoneGrossular=0xff007b
         oreEndstoneSpessartine=0xff007b
         oreEndstonePyrolusite=0xff007b
-        oreEndstoneTantalite=0xff007b               
-        
+        oreEndstoneTantalite=0xff007b
+
         //Molybdenite Veins
         //white and purple
         oreWulfenite=0xffffff
@@ -237,11 +237,11 @@ general {
         orePowellite=0x6a3cb5
         oreGravelWulfenite=0xffffff
         oreGravelMolybdenite=0x6a3cb5
-        oreGravelPowellite=0x6a3cb5   
+        oreGravelPowellite=0x6a3cb5
         oreEndstoneWulfenite=0xffffff
         oreEndstoneMolybdenite=0x6a3cb5
-        oreEndstonePowellite=0x6a3cb5             
-        
+        oreEndstonePowellite=0x6a3cb5
+
         //Monazite Veins
         //vibrant magenta
         oreBastnasite=0xff00ff
@@ -249,8 +249,8 @@ general {
         oreNeodymium=0xff00ff
         oreGravelBastnasite=0xff00ff
         oreGravelMonazite=0xff00ff
-        oreGravelNeodymium=0xff00ff        
-        
+        oreGravelNeodymium=0xff00ff
+
         //Nickel Veins
         //vibrant teal
         oreGarnierite=0x00ff99
@@ -260,7 +260,7 @@ general {
         oreGravelGarnierite=0x00ff99
         oreGravelPentlandite=0x00ff99
         oreGravelNickel=0x00ff99
-        oreGravelCobaltite=0x00ff99 
+        oreGravelCobaltite=0x00ff99
         oreEndstoneGarnierite=0x00ff99
         oreEndstonePentlandite=0x00ff99
         oreEndstoneNickel=0x00ff99
@@ -268,13 +268,13 @@ general {
         oreNetherrackGarnierite=0x00ff99
         oreNetherrackPentlandite=0x00ff99
         oreNetherrackNickel=0x00ff99
-        oreNetherrackCobaltite=0x00ff99                       
-        
+        oreNetherrackCobaltite=0x00ff99
+
         //Oilsands Veins
         //gray
         oreOilsands=0x999999
-        oreGravelOilsands=0x999999        
-        
+        oreGravelOilsands=0x999999
+
         //Olivine Veins
         //olive green
         oreBentonite=0x648047
@@ -288,8 +288,8 @@ general {
         oreEndstoneBentonite=0x648047
         oreEndstoneMagnesite=0x648047
         oreEndstoneOlivine=0x648047
-        oreEndstoneGlauconite=0x648047                
-        
+        oreEndstoneGlauconite=0x648047
+
         //Pitchblende Veins
         //vibrant lime
         orePitchblende=0xbbff00
@@ -297,8 +297,8 @@ general {
         oreUraninite=0xbbff00
         oreGravelPitchblende=0xbbff00
         oreGravelUranium=0xbbff00
-        oreGravelUraninite=0xbbff00        
-        
+        oreGravelUraninite=0xbbff00
+
         //Platinum Veins
         //baby pink and baby blue
         orePlatinum=0x6ec2ff
@@ -307,7 +307,7 @@ general {
         oreGravelPlatinum=0x6ec2ff
         oreGravelPalladium=0xff879b
         oreEndstonePlatinum=0x6ec2ff
-        oreEndstonePalladium=0xff879b        
+        oreEndstonePalladium=0xff879b
 
         //Quartz Veins
         //white-mint green
@@ -318,9 +318,9 @@ general {
         oreGravelQuartzite=0xc2ffd1
         oreGravelBarite=0xc2ffd1
         oreGravelNetherQuartz=0xc2ffd1
-        oreGravelCertusQuartz=0xc2ffd1  
-        oreNetherrackNetherQuartz=0xc2ffd1              
-        
+        oreGravelCertusQuartz=0xc2ffd1
+        oreNetherrackNetherQuartz=0xc2ffd1
+
         //Redstone Veins
         //vibrant red
         oreRedstone=0xff0000
@@ -331,8 +331,8 @@ general {
         oreGravelCinnabar=0xff0000
         oreNetherrackRedstone=0xff0000
         oreNetherrackRuby=0xff0000
-        oreNetherrackCinnabar=0xff0000                
-        
+        oreNetherrackCinnabar=0xff0000
+
         //Salt Veins
         //white and pink
         oreSalt=0xffffff
@@ -354,8 +354,8 @@ general {
         oreGravelAlmandine=0xa30000
         oreGravelPyrope=0xa30000
         oreGravelSaphire=0xa55cff
-        oreGravelGreenSapphire=0xa55cff        
-        
+        oreGravelGreenSapphire=0xa55cff
+
         //Soapstone Veins
         //pale green
         oreSoapstone=0x97e693
@@ -374,15 +374,15 @@ general {
         oreGravelTetrahedrite=0xff7878
         oreGravelStibnite=0xff7878
         oreNetherrackTetrahedrite=0xff7878
-        oreNetherrackStibnite=0xff7878                
-        
+        oreNetherrackStibnite=0xff7878
+
         //Tin Veins
         //light gray
         oreTin=0xbcdce6
         oreCassiterite=0xbcdce6
         oreGravelTin=0xbcdce6
-        oreGravelCassiterite=0xbcdce6        
-        
+        oreGravelCassiterite=0xbcdce6
+
         //Tungstate Veins
         //vibrant violet
         oreScheelite=0x7300ff
@@ -393,8 +393,8 @@ general {
         oreGravelLithium=0x7300ff
         oreEndstoneScheelite=0x7300ff
         oreEndstoneTungstate=0x7300ff
-        oreEndstoneLithium=0x7300ff                
-        
+        oreEndstoneLithium=0x7300ff
+
         //Zinc Veins
         //white and blue
         oreZinc=0xffffff
@@ -403,8 +403,8 @@ general {
         oreGravelZinc=0xffffff
         oreGravelPyrite=0xffffff
         oreGravelSphalerite=0x00a2ff
-        oreNetherrackSphalerite=0x00a2ff 
-        oreNetherrackPyrite=0xffffff               
+        oreNetherrackSphalerite=0x00a2ff
+        oreNetherrackPyrite=0xffffff
 
         //Nether Specific
         //Nether Sulfur Veins, Bright Yellow
@@ -420,8 +420,8 @@ general {
 
         //Black Quartz
         oreQuartzBlack=0x000108
-        
-        
+
+
         glowstone=0xE9E68E
 
      >
@@ -429,7 +429,7 @@ general {
     # Ore dictionary entries considered common ores, requiring the common ore scanner module.
     # Use this to mark ores as common, as opposed to rare (see oresRare).
     S:oresCommon <
-        
+
 
         glowstone
 
@@ -437,120 +437,120 @@ general {
         oreApatite
         orePhosphor
         oreGravelApatite
-        oreGravelPhosphor                       
-		
-		//Copper Veins
-		oreChalcopyrite
-		oreGravelChalcopyrite
-      
-       	//Galena Veins
+        oreGravelPhosphor
+
+        //Copper Veins
+        oreChalcopyrite
+        oreGravelChalcopyrite
+
+        //Galena Veins
         oreGalena
         oreSilver
         oreLead
         oreGravelGalena
         oreGravelSilver
-        oreGravelLead        
-		
-		//Iron Veins
-		oreYellowLimonite
-		oreBrownLimonite 
-		oreBandedIron
-		oreMalachite
-		oreGravelYellowLimonite
-		oreGravelBrownLimonite 
-		oreGravelBandedIron
-		oreGravelMalachite
+        oreGravelLead
+
+        //Iron Veins
+        oreYellowLimonite
+        oreBrownLimonite
+        oreBandedIron
+        oreMalachite
+        oreGravelYellowLimonite
+        oreGravelBrownLimonite
+        oreGravelBandedIron
+        oreGravelMalachite
 
         //Lapis Veins
         oreSodalite
-		oreGravelSodalite
-		 				
+        oreGravelSodalite
 
-		//Lignite Coal Veins
-		oreLignite
-		oreGravelLignite				
 
-		//Magnetite Veins
+        //Lignite Coal Veins
+        oreLignite
+        oreGravelLignite
+
+        //Magnetite Veins
         oreMagnetite
         oreIron
         oreVanadiumMagnetite
-        oreGold		
+        oreGold
         oreGravelMagnetite
         oreGravelIron
         oreGravelVanadiumMagnetite
-        oreGravelGold	        
+        oreGravelGold
 
-		//Oilsands Vein
-		oreOilsands
-		oreCoal
-		oreGravelOilsands
-		oreGravelCoal		
+        //Oilsands Vein
+        oreOilsands
+        oreCoal
+        oreGravelOilsands
+        oreGravelCoal
 
-		//Quartz Veins
+        //Quartz Veins
         oreQuartzite
         oreBarite
         oreNetherQuartz
-        oreCertusQuartz		
+        oreCertusQuartz
         oreGravelQuartzite
         oreGravelBarite
         oreGravelNetherQuartz
-        oreGravelCertusQuartz	        
+        oreGravelCertusQuartz
 
-		//Redstone Veins
+        //Redstone Veins
         oreRedstone
         oreRuby
-        oreCinnabar	
+        oreCinnabar
         oreGravelRedstone
         oreGravelRuby
-        oreGravelCinnabar	        	
+        oreGravelCinnabar
 
-		//Salt Veins
+        //Salt Veins
         oreSalt
         oreRockSalt
         oreLepidolite
-        oreSpodumene	
+        oreSpodumene
         oreGravelSalt
         oreGravelRockSalt
         oreGravelLepidolite
-        oreGravelSpodumene        
+        oreGravelSpodumene
 
-		//Soapstone Veins
-		oreSoapstone
-		oreGlauconite
-		orePentlandite
-		oreTalc
-		oreGravelSoapstone
-		oreGravelGlauconite
-		oreGravelPentlandite
-		oreGravelTalc		
+        //Soapstone Veins
+        oreSoapstone
+        oreGlauconite
+        orePentlandite
+        oreTalc
+        oreGravelSoapstone
+        oreGravelGlauconite
+        oreGravelPentlandite
+        oreGravelTalc
 
-		//Tetrahedrite Veins
-		oreTetrahedrite
-		oreStibnite
-		oreCopper
-		oreGravelTetrahedrite
-		oreGravelStibnite
-		oreGravelCopper		
+        //Tetrahedrite Veins
+        oreTetrahedrite
+        oreStibnite
+        oreCopper
+        oreGravelTetrahedrite
+        oreGravelStibnite
+        oreGravelCopper
 
         //Tin Veins
         oreTin
-		oreCassiterite 
+        oreCassiterite
         oreGravelTin
-		oreGravelCassiterite 		 		
+        oreGravelCassiterite
 
-		//Zinc Veins
-		oreZinc
-		orePyrite
-		oreSphalerite
-		oreGravelZinc
-		oreGravelPyrite
-		oreGravelSphalerite
+        //Zinc Veins
+        oreZinc
+        orePyrite
+        oreSphalerite
+        oreGravelZinc
+        oreGravelPyrite
+        oreGravelSphalerite
 
-		//Nether Veins
-		//Sulfur
-        oreNetherrackSphalerite 
-        oreNetherrackPyrite	
-        oreNetherrackSulfur	
+        //Nether Veins
+        //Sulfur
+        oreNetherrackSphalerite
+        oreNetherrackPyrite
+        oreNetherrackSulfur
 
         //Nether Quartz
         oreNetherrackNetherQuartz
@@ -559,13 +559,13 @@ general {
         oreNetherrackMagnetite
         oreNetherrackVanadiumMagnetite
         oreNetherrackGold
-        oreNetherrackIron 
+        oreNetherrackIron
 
         //Iron Veins
         oreNetherrackYellowLimonite
         oreNetherrackBrownLimonite
         oreNetherrackBandedIron
-        oreNetherrackMalachite   
+        oreNetherrackMalachite
 
         //Moon Veins
         oreDilithium
@@ -575,13 +575,13 @@ general {
         oreEndstoneBentonite
         oreEndstoneMagnesite
         oreEndstoneOlivine
-        oreEndstoneGlauconite 
+        oreEndstoneGlauconite
 
         //Lapis Veins
         oreEndstoneLazurite
         oreEndstoneSodalite
         oreEndstoneCalcite
-        oreEndstoneLapis                 
+        oreEndstoneLapis
 
 
      >
@@ -593,20 +593,20 @@ general {
     # ores that do follow this pattern.
     S:oresRare <
 
-    	//Included in this by omission from above are
-    	//Tungstate Veins
-    	//Sapphire Veins
-    	//Platinum Veins
-    	//Olivine Veins
-    	//Pitchblende Veins
-    	//Monazite Veins
-    	//Molybdenum Veins
-    	//Manganese Veins
-    	//Lapis Veins (Minus the Sodalite)
-    	//Diamond Veins
-    	//Beryllium Veins
-    	//Bauxite Veins (Minus the tin)
-    	//To see all ores included in these veins, please see the gtce config worldgen file
+        //Included in this by omission from above are
+        //Tungstate Veins
+        //Sapphire Veins
+        //Platinum Veins
+        //Olivine Veins
+        //Pitchblende Veins
+        //Monazite Veins
+        //Molybdenum Veins
+        //Manganese Veins
+        //Lapis Veins (Minus the Sodalite)
+        //Diamond Veins
+        //Beryllium Veins
+        //Bauxite Veins (Minus the tin)
+        //To see all ores included in these veins, please see the gtce config worldgen file
 
      >
 


### PR DESCRIPTION
Add unique colors to every overworld deposit, to make them stand out at a glance. Also add more copper, tin, and iron ores to "common"-type scannables, remove aluminium and cinnabar from common-type.