### PR TITLE
Remove Hot Naquadah Ingot

### DIFF
--- a/overrides/scripts/BlastFurnace.zs
+++ b/overrides/scripts/BlastFurnace.zs
@@ -186,6 +186,8 @@ blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:10045>,<gregtech:met
 
 //Naquadah [tier 11]
 blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2307>], [null]).remove();	
+freezer.findRecipe(120, [<gregtech:meta_item_1:11307>], [null]).remove();
+mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:11307>);	
 furnace.addRecipe(<gregtech:meta_item_1:10307>, <gregtech:meta_item_1:2307>, 0.0);
 
 //Enriched Naquadah


### PR DESCRIPTION
Since the way to obtain Naquadah ingots is through just smelting the dust, this removes the hot ingot to prevent confusion.