### PR TITLE
Enable Reservoirs from Thermal Expansion

### DIFF
--- a/overrides/config/cofh/thermalexpansion/common.cfg
+++ b/overrides/config/cofh/thermalexpansion/common.cfg
@@ -223,8 +223,8 @@ Item {
 
     Reservoir {
         # Adjust this value to change the amount of Fluid (in mB) stored by a Basic Reservoir. This base value will scale with item level. [range: 2000 ~ 100000, default: 10000]
-        I:BaseCapacity=10000
-        B:Enable=false
+        I:BaseCapacity=50000
+        B:Enable=true
     }
 
     Satchel {

--- a/overrides/scripts/Reservoirs.zs
+++ b/overrides/scripts/Reservoirs.zs
@@ -1,0 +1,62 @@
+#priority -999
+
+// Lowest priority to make recipes appear on the last page.
+
+import crafttweaker.item.IItemStack;
+import crafttweaker.item.IIngredient;
+import crafttweaker.data.IData;
+import crafttweaker.recipes.ICraftingInfo;
+
+recipes.removeByRegex("thermalexpansion:(reservoir|reservoir_[1-4].?)$");
+
+/* 
+	Define reservoirs and tanks.
+*/
+val tanks as IItemStack[IItemStack] = {
+	<thermalexpansion:reservoir:0>: basictank
+	, <thermalexpansion:reservoir:1>: hardenedtank
+	, <thermalexpansion:reservoir:2>: reinforcedtank
+	, <thermalexpansion:reservoir:3>: signalumtank
+	, <thermalexpansion:reservoir:4>: resonanttank
+	, <thermalexpansion:reservoir:32000>: <thermalexpansion:tank>
+		.withTag({RSControl: 0 as byte, Creative: 1 as byte, Level: 4 as byte})
+};
+
+function craftingFunc(out as IItemStack, tank as IItemStack) as IItemStack {
+	var output as IItemStack = out;
+
+	/* 
+		Restore NBT tags selectively.
+	*/
+	for tagName in ["ench", "Fluid", "display"] as string[] {
+		val tag as IData = tank.tag.memberGet(tagName);
+
+		if (!isNull(tag)) {
+			output = output.updateTag({
+				[tagName]: tag
+			});
+		}
+	}
+
+	return output;
+} 
+
+for reservoir, tank in tanks {
+	/* 
+		Add Portable Tank -> Reservoir conversion recipe.
+	*/
+	recipes.addShapeless(reservoir, [tank.marked("tank")]
+		, function(out, ins, cInfo) {
+			return craftingFunc(out, ins.tank);
+		} as crafttweaker.recipes.IRecipeFunction
+	);
+
+	/* 
+		Add Reservoir -> Portable Tank conversion recipe.
+	*/
+	recipes.addShapeless(tank, [reservoir.marked("tank")]
+		, function(out, ins, cInfo) {
+			return craftingFunc(out, ins.tank);
+		} as crafttweaker.recipes.IRecipeFunction
+	);
+}


### PR DESCRIPTION
I figured this would be the best way to introduce Reservoirs without having to come up with new recipes.

This PR enables Reservoirs and adds two-way conversion recipes while removing default recipes and leaving dye recipes intact.

Any Portable Tank can be converted 1:1 to Reservoir of its tier and vice versa (including creative). Craft a Reservoir if you need one, then craft it back into a Portable Tank when you no longer need it.

![image](https://user-images.githubusercontent.com/22255622/77823935-d8fdf380-7152-11ea-973e-bb4db0181872.png)

Both Portable Tanks and Reservoirs retain contents, display names and enchantments during the conversion.
