### PR TITLE
Add Infinity Grain Block as Microminer output

### DIFF
--- a/overrides/scripts/Microverse.zs
+++ b/overrides/scripts/Microverse.zs
@@ -444,6 +444,7 @@ signalum1.addItemInput(<advancedrocketry:satelliteprimaryfunction:1>);
 signalum1.addItemInput(<thermalfoundation:material:1027> * 64);
 signalum1.addItemOutput(<contenttweaker:denseoilshale> * 64);
 signalum1.addItemOutput(<contenttweaker:denseoilshale> * 64);
+signalum1.addItemOutput(<enderio:block_infinity> * 16);
 signalum1.build();
 
 


### PR DESCRIPTION
Closes #325 

Note, this is not meant to replace proper automation of Infinity Grains, which is why it only gives 16 blocks, but instead to relieve a little bit of the waiting post tank.