### PR TITLE
Fix the oil rig quest, adjust its power requirement

### DIFF
--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -34173,7 +34173,7 @@
             },
             "6:10": {
               "Count:3": 1,
-              "Damage:2": 2,
+              "Damage:2": 3,
               "OreDict:8": "",
               "id:8": "modularmachinery:blockenergyinputhatch"
             },

--- a/overrides/scripts/Microverse.zs
+++ b/overrides/scripts/Microverse.zs
@@ -1031,7 +1031,7 @@ mmRecipe("naquadareactorhmk2b", "naquadahreactormk2", 12000)
 
 // Oil Drilling Rig mechanics
 mmRecipe("oildrillingrig", "oildrillingrig", 80)
-	.addEnergyPerTickInput(17500)
+	.addEnergyPerTickInput(1600)
 	.addFluidInput(<liquid:drilling_fluid> * 40)
 	.addItemInput(<inspirations:pipe>)
 	.setChance(0.04)

--- a/overrides/scripts/Microverse.zs
+++ b/overrides/scripts/Microverse.zs
@@ -1031,7 +1031,7 @@ mmRecipe("naquadareactorhmk2b", "naquadahreactormk2", 12000)
 
 // Oil Drilling Rig mechanics
 mmRecipe("oildrillingrig", "oildrillingrig", 80)
-	.addEnergyPerTickInput(1600)
+	.addEnergyPerTickInput(16000)
 	.addFluidInput(<liquid:drilling_fluid> * 40)
 	.addItemInput(<inspirations:pipe>)
 	.setChance(0.04)


### PR DESCRIPTION
Closes #433 

This adjusts the power requirement of the oil rig down to 16000, so that it will require an EV energy input instead of an IV energy input. Also fixes the quest in the quest book requiring the incorrect energy input hatch.