### PR TITLE
Remove recipes.zs

### DIFF
--- a/overrides/scripts/recipes.zs
+++ b/overrides/scripts/recipes.zs
@@ -1,6 +1,0 @@
-//This file was created via CT-GUI! Editing it is not advised!
-//Don't touch me!
-//#Remove
-//Don't touch me!
-//#Add
-//File End


### PR DESCRIPTION
The file is empty, therefore is unneeded. Removing the file is just a bit of cleanup.