### PR TITLE
Bug: Unable to complete quest 'Basic Capacitor Bank' while using a Flux Capacitor. #488

### DIFF
--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -2426,7 +2426,7 @@
           "autoConsume:1": 0,
           "consume:1": 0,
           "groupDetect:1": 0,
-          "ignoreNBT:1": 0,
+          "ignoreNBT:1": 1,
           "index:3": 0,
           "partialMatch:1": 1,
           "requiredItems:9": {


### PR DESCRIPTION
Advanced and Vibrant Capacitor bank quests already have ignoreNBT. This fixes Basic one.

fixes #488

Tested locally.