### PR TITLE
Fix some issues with Pyrolusite Vein Spawning

### DIFF
--- a/overrides/config/gregtech/worldgen/overworld/manganese_vein.json
+++ b/overrides/config/gregtech/worldgen/overworld/manganese_vein.json
@@ -2,7 +2,7 @@
   "weight": 25,
   "density": 0.3,
   "max_height": 30,
-  "min_height": 20,
+  "min_height": 10,
   "dimension_filter": ["name:*(overworld|lostcities)"],
   "generator": {
     "type": "ellipsoid",

--- a/overrides/config/gregtech/worldgen/overworld/molybdenum_vein.json
+++ b/overrides/config/gregtech/worldgen/overworld/molybdenum_vein.json
@@ -2,7 +2,7 @@
   "weight": 20,
   "density": 0.5,
   "max_height": 30,
-  "min_height": 20,
+  "min_height": 10,
   "dimension_filter": ["name:*(overworld|lostcities)"],
   "generator": {
     "type": "ellipsoid",


### PR DESCRIPTION
This fixes some issues with the spawning of Pyrolusite veins brought up by Talchas on the discord, see conversation here: https://discordapp.com/channels/564247906991996928/666533661428154388/712114670944649310

This fix entails switching the minimum spawning height of the vein to 10, so that the max height, with its height offset of 30/2 + 4 = 19 which leads to a offset value of 30 - 19 = 11, is greater than the minimum height of 10, meaning that the vein would spawn. With the minimum height of 20, the minimum height was greater than the offset, leading to the vein not spawning. See the specifics of the calculations here: https://github.com/GregTechCE/GregTech/blob/42e2546c9e7fba3fa1ae6594dc9c769de3fbb81e/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java#L229

This will require generation of new chucks, as would be expected by worldgen change, and keep in mind that this vein still is very rare.