### PR TITLE
Update theoneprobe.cfg

### DIFF
--- a/overrides/config/theoneprobe.cfg
+++ b/overrides/config/theoneprobe.cfg
@@ -193,6 +193,7 @@ theoneprobe {
         storagedrawersextra:extra_drawers
         storagedrawers:compdrawers
         storagedrawers:customdrawers
+        framedcompactdrawers:framed_compact_drawer
      >
 
     # Show the growth level of crops (0 = not, 1 = always, 2 = sneak) [range: 0 ~ 2, default: 1]


### PR DESCRIPTION
Framed Compacting Drawers now show their content without sneaking like there Storage Drawers equivalent.