### PR TITLE
Make the void world an AR planet

### DIFF
--- a/overrides/config/advRocketry/advancedRocketry.cfg
+++ b/overrides/config/advRocketry/advancedRocketry.cfg
@@ -97,7 +97,7 @@ general {
     D:OxygenVentPowerMultiplier=1.0
 
     # setting this to false will will prevent resetPlanetsFromXML from being set to false upon world reload.  Recommended for those who want to force ALL saves to ALWAYS use the planetDefs XML in the /config folder.  Essentially that 'Are you sure you're sure' option.  If resetPlanetsFromXML is false, this option does nothing. [default: true]
-    B:ResetOnlyOnce=true
+    B:ResetOnlyOnce=false
 
     # The largest size a space station can be.  Should also be a power of 2 (512, 1024, 2048, 4096, ...).  CAUTION: CHANGING THIS OPTION WILL DAMAGE EXISTING STATIONS!!!
     I:SpaceStationBuildRadius=2048

--- a/overrides/config/advRocketry/advancedRocketry.cfg
+++ b/overrides/config/advRocketry/advancedRocketry.cfg
@@ -200,7 +200,7 @@ general {
     I:pointsPerDilithium=500
 
     # setting this to true will force AR to read from the XML file in the config/advRocketry instead of the local data, intended for use pack developers to ensure updates are pushed through [default: false]
-    B:resetPlanetsFromXML=false
+    B:resetPlanetsFromXML=true
 
     # Mod:Blockname  for example "minecraft:chest" [default: [minecraft:portal], [minecraft:bedrock], [minecraft:snow_layer], [minecraft:water], [minecraft:flowing_water], [minecraft:lava], [minecraft:flowing_lava]]
     S:rocketBlockBlackList <

--- a/overrides/config/advRocketry/planetDefs.xml
+++ b/overrides/config/advRocketry/planetDefs.xml
@@ -19,6 +19,16 @@
 				<rotationalPeriod>128000</rotationalPeriod>
 				<atmosphereDensity>0</atmosphereDensity>
 			</planet>
+			<planet name="Void" DIMID="119" dimMapping="" customIcon="Moon">
+				<isKnown>true</isKnown>
+				<fogColor>1.0,1.0,1.0</fogColor>
+				<skyColor>1.0,1.0,1.0</skyColor>
+				<gravitationalMultiplier>100</gravitationalMultiplier>
+				<orbitalDistance>110</orbitalDistance>
+				<orbitalPhi>0</orbitalPhi>
+				<rotationalPeriod>24000</rotationalPeriod>
+				<atmosphereDensity>100</atmosphereDensity>
+			</planet>			
 		</planet>
 		<planet name="Mercury" DIMID="101" customIcon="lava">
 		    <biomeIds>biomesoplenty:volcanic_island</biomeIds>


### PR DESCRIPTION
This allows for launching rockets from the void world, instead of having to go back to the overworld if the player decides to launch a rocket. Works on both new and old saves. 

One note, it would be nice to figure out if it is possible to resize the planets on the AR galaxy map, as the void world is currently the size of the Earth.