### PR TITLE
Modify Facade hiding so that one is visible

### DIFF
--- a/overrides/scripts/JEICleanup.zs
+++ b/overrides/scripts/JEICleanup.zs
@@ -47,7 +47,17 @@ if(!isNull(ae2)) {
 
     for item in ae2Items {
         if(item.displayName has "Cable Facade") {
-            mods.jei.JEI.hide(item);
+
+            if(item.displayName has "Block of Omnium") {
+
+                item.addTooltip(format.darkAqua("Facades can be crafted from most blocks, but are hidden from JEI to reduce clutter"));
+            }
+            else {
+               mods.jei.JEI.hide(item); 
+            }
         }
     }
 }
+
+//Hiding the GTCE omnium block facade version
+mods.jei.JEI.hide(<appliedenergistics2:facade>.withTag({damage: 8, item: "gregtech:compressed_17"}));


### PR DESCRIPTION
Closes #538 

Ones way of resolving the facade issue. I had made this issue originally because I forgot the recipe for the facades, and they were all hidden in JEI, so I could not look them up. This just adds one facade back into JEI and adds a tooltip to the facade stating that most blocks can be used to create facades. I chose Omnium blocks as the material to represent the pack.