### PR TITLE
Fix Pure Crystals in Phytogenic Insolator.

### DIFF
--- a/overrides/scripts/ThermalExpansion.zs
+++ b/overrides/scripts/ThermalExpansion.zs
@@ -495,6 +495,6 @@ mods.thermalexpansion.Insolator.addRecipe(<appliedenergistics2:material:11>, <ap
 //Pure Fluix
 mods.thermalexpansion.Insolator.addRecipe(<appliedenergistics2:material:12>, <appliedenergistics2:crystal_seed:1200>.withTag({progress: 1200}), <minecraft:glowstone_dust>, 40000);
 
-mods.jei.JEI.addDescription(<appliedenergistics2:material:10>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot.");
-mods.jei.JEI.addDescription(<appliedenergistics2:material:11>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot.");
-mods.jei.JEI.addDescription(<appliedenergistics2:material:12>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot.");
+mods.jei.JEI.addDescription(<appliedenergistics2:material:10>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot. Augments do not work for this craft.");
+mods.jei.JEI.addDescription(<appliedenergistics2:material:11>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot. Augments do not work for this craft.");
+mods.jei.JEI.addDescription(<appliedenergistics2:material:12>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot. Augments do not work for this craft.");

--- a/overrides/scripts/ThermalExpansion.zs
+++ b/overrides/scripts/ThermalExpansion.zs
@@ -485,3 +485,16 @@ furnace.remove(<thermalfoundation:rockwool:7>, <thermalfoundation:material:864>)
 //Satchel Removal
 recipes.removeByRecipeName("thermalexpansion:satchel_1");
 recipes.removeByRecipeName("thermalexpansion:satchel_7");
+
+//Pure Certus
+mods.thermalexpansion.Insolator.addRecipe(<appliedenergistics2:material:10>, <appliedenergistics2:crystal_seed>.withTag({progress: 0}), <minecraft:glowstone_dust>, 40000);
+
+//Pure Nether Quartz
+mods.thermalexpansion.Insolator.addRecipe(<appliedenergistics2:material:11>, <appliedenergistics2:crystal_seed:600>.withTag({progress: 600}), <minecraft:glowstone_dust>, 40000);
+
+//Pure Fluix
+mods.thermalexpansion.Insolator.addRecipe(<appliedenergistics2:material:12>, <appliedenergistics2:crystal_seed:1200>.withTag({progress: 1200}), <minecraft:glowstone_dust>, 40000);
+
+mods.jei.JEI.addDescription(<appliedenergistics2:material:10>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot.");
+mods.jei.JEI.addDescription(<appliedenergistics2:material:11>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot.");
+mods.jei.JEI.addDescription(<appliedenergistics2:material:12>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot.");


### PR DESCRIPTION
Closes #550 

Fixes the Pure Crystal recipes in the Phytogenic Insolator. In addition, adds a JEI description to the final crystals giving more information on how they are made, and included the fact that the Fertilizer slot has to be unlocked when making them in the Insolator.

Some issues: 
- Was having errors removing the recipes, in that an error message would pop up in chat stating that the recipe was missing.
- Since the amount of water consumed is based on the power, I could not restore the recipe to its original power usage, and had to reduce the recipe to 40 kRF to fit the amount of water in the Insolator.
- As brought up in #550, augments do not work.