### PR TITLE
Add Flux Networks with Gregged Recipes.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -781,13 +781,18 @@
       "required": true
     },
     {
-    "projectID": 237701,
-    "fileID": 2560638,
-    "required": true
+      "projectID": 237701,
+      "fileID": 2560638,
+      "required": true
     },
     {
       "projectID": 383632,
       "fileID": 3000477,
+      "required": true
+    },
+	{
+      "projectID": 248020,
+      "fileID": 2842381,
       "required": true
     }
   ],

--- a/overrides/config/flux_networks.cfg
+++ b/overrides/config/flux_networks.cfg
@@ -1,0 +1,77 @@
+# Configuration file
+
+blacklists {
+    # a blacklist for blocks which flux connections shouldn't connect to, use format 'modid:name@meta'
+    S:"Block Connection Blacklist" <
+        actuallyadditions:block_phantom_energyface
+     >
+
+    # a blacklist for items which the Flux Controller shouldn't transfer to, use format 'modid:name@meta'
+    S:"Item Transfer Blacklist" <
+     >
+}
+
+
+client {
+    # Displays: Transfer Limit & Priority etc [default: true]
+    B:"Enable Advanced One Probe Info"=true
+
+    # Displays: Network Name, Live Transfer Rate & Internal Buffer [default: true]
+    B:"Enable Basic One Probe Info"=true
+
+    # Enable navigation buttons sound when pressing it [default: true]
+    B:"Enable GUI Button Sound"=true
+
+    # Displays Advanced Info when sneaking only [default: true]
+    B:"Enable sneaking to display Advanced One Probe Info"=true
+}
+
+
+energy {
+    #  [range: 0 ~ 2147483647, default: 1000000]
+    I:"Basic Storage Capacity"=1000000
+
+    #  [range: 0 ~ 2147483647, default: 20000]
+    I:"Basic Storage Transfer"=20000
+
+    # The default transfer limit of a flux connector [range: 0 ~ 2147483647, default: 800000]
+    I:"Default Transfer Limit"=2147483647
+
+    #  [range: 0 ~ 2147483647, default: 128000000]
+    I:"Gargantuan Storage Capacity"=128000000
+
+    #  [range: 0 ~ 2147483647, default: 1440000]
+    I:"Gargantuan Storage Transfer"=1440000
+
+    #  [range: 0 ~ 2147483647, default: 8000000]
+    I:"Herculean Storage Capacity"=8000000
+
+    #  [range: 0 ~ 2147483647, default: 120000]
+    I:"Herculean Storage Transfer"=120000
+}
+
+
+general {
+    # Allows flux tiles to work as chunk loaders [default: true]
+    B:"Allow Flux Chunk Loading"=false
+
+    # Enables redstones being compressed with the bedrock and obsidian to get flux [default: true]
+    B:"Enable Flux Recipe"=false
+
+    # Enables redstone being turned into Flux when dropped in fire. (Need "Enable Flux Recipe" = true, so the default recipe can't be disabled if turns this on) [default: false]
+    B:"Enable Old Recipe"=false
+}
+
+
+networks {
+    # Allows someone to be a network super admin, otherwise, no one can access or dismantle your flux devices or delete your networks without permission [default: true]
+    B:"Allow Network Super Admin"=true
+
+    # Maximum networks each player can have. -1 = no limit [range: -1 ~ 2147483647, default: 3]
+    I:"Maximum Networks Per Player"=-1
+
+    # See ops.json. If the player has permission level equal or greater to the value set here they will be able to Activate Super Admin. Setting this to 0 will allow anyone to active Super Admin. [range: 0 ~ 2147483647, default: 1]
+    I:"Permission level required to activate Super Admin"=1
+}
+
+

--- a/overrides/scripts/FluxNetworks.zs
+++ b/overrides/scripts/FluxNetworks.zs
@@ -1,0 +1,61 @@
+import scripts.CommonVars.makeShaped as makeShaped;
+
+print("--- loading FluxNetworks.zs ---");
+
+//Remove all default recipes
+recipes.remove(<fluxnetworks:fluxcore>);
+recipes.remove(<fluxnetworks:fluxconfigurator>);
+recipes.remove(<fluxnetworks:fluxblock>);
+recipes.remove(<fluxnetworks:fluxplug>);
+recipes.remove(<fluxnetworks:fluxpoint>);
+recipes.remove(<fluxnetworks:fluxcontroller>);
+recipes.remove(<fluxnetworks:fluxstorage>);
+recipes.remove(<fluxnetworks:herculeanfluxstorage>);
+recipes.remove(<fluxnetworks:gargantuanfluxstorage>);
+
+//Flux Plug
+makeShaped("of_flux_plug", <fluxnetworks:fluxplug>,
+    ["CSC",
+     "XIX",
+     "CUC"],
+    { C : <ore:circuitMaster>, //T6 Circuit
+      S : <gregtech:meta_item_1:32695>, //LuV Sensor
+      X : <enderio:item_endergy_conduit:11>, //Superconductor Wire
+	  I : <actuallyadditions:block_phantom_energyface>, //Phantom Energyface
+	  U : <gregtech:machine:10704> //LuV CEU 16x
+      });
+
+//Flux Point
+makeShaped("of_flux_point", <fluxnetworks:fluxpoint>,
+    ["CUC",
+     "XIX",
+     "CSC"],
+    { C : <ore:circuitMaster>, //T6 Circuit
+      S : <gregtech:meta_item_1:32695>, //LuV Sensor
+      X : <enderio:item_endergy_conduit:11>, //Superconductor Wire
+	  I : <actuallyadditions:block_phantom_energyface>, //Phantom Energyface
+	  U : <gregtech:machine:10704> //LuV CEU 16x
+      });
+	  
+//Flux Controller
+makeShaped("of_flux_controller", <fluxnetworks:fluxcontroller>,
+    ["SPE",
+     "CBC",
+     "XIX"],
+    { C : <ore:circuitMaster>, //T6 Circuit
+      S : <gregtech:meta_item_1:32695>, //LuV Sensor
+	  E : <gregtech:meta_item_1:32685>, //LuV Emitter
+      X : <enderio:item_endergy_conduit:11>, //Superconductor Wire
+	  I : <actuallyadditions:block_phantom_energyface>, //AA Phantom Energyface
+	  B : <gregtech:machine:637>, //LuV Battery Buffer 16x
+	  P : <actuallyadditions:block_player_interface> //AA Player Interface
+      });
+
+//Flux Configurator
+makeShaped("of_flux_configurator", <fluxnetworks:fluxconfigurator>,
+    ["  S",
+     " R ",
+     "R  "],
+    { S : <gregtech:meta_item_1:32695>, //LuV Sensor
+      R : <ore:stickEnderium> //Enderium Rod
+      });


### PR DESCRIPTION
Remade because I'm dumb. 

Flux Networks would be a decent addition to the pack, despite being very powerful, because of how poorly EnderIO wireless transfer scales into late-game. Some people have also complained about AE2 power transfer being somewhat janky for them. While AE power transfer is quite strong as well, this would be a significantly more expensive alternative and allowing you to losslessly transfer power between dimensions for that increased cost. 

I've collected some feedback from the discord members on what tier would be appropriate for Flux Networks to be at and what the recipes should be like and came up with these changes to it for possibly being added to the pack officially.

Here are the recipes in picture form for your convenience.

![image](https://user-images.githubusercontent.com/2375161/85937996-ecd60480-b8bd-11ea-9906-3dfdedb7205e.png)

The circuits are oredicted of course. 

I would be fine with bumping this recipe up to ZPM tier, however I feel like LuV is the sweet spot here. Any other feedback on recipe changes is welcome, of course. If you're curious on justification for certain items being used, feel free to ask.