### PR TITLE
Add macerator recipes for first tier compressed blocks.

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -891,3 +891,20 @@ macerator.recipeBuilder()
 
 //Remove Unobtainable Clay recipe
 recipes.removeByRecipeName("thermalfoundation:clay_ball");
+
+//Compressed Materials Recipes
+
+macerator.recipeBuilder()
+	.inputs(<extrautils2:compressedcobblestone>)
+	.outputs(<extrautils2:compressedgravel>)
+	.duration(144).EUt(10).buildAndRegister();
+
+macerator.recipeBuilder()
+	.inputs(<extrautils2:compressedgravel>)
+	.outputs(<extrautils2:compressedsand>)
+	.duration(144).EUt(10).buildAndRegister();
+
+macerator.recipeBuilder()
+	.inputs(<extrautils2:compressedsand>)
+	.outputs(<contenttweaker:block_dust> * 9)
+	.duration(144).EUt(10).buildAndRegister();


### PR DESCRIPTION
Closes #352 

This PR adds recipes in the macerator for first tier compressed blocks. In this PR, the compressed block will macerate down into another compressed block, but I am also open to having the compressed block being compressed down into 9 of the individual blocks in the next tier. Once the chain reaches compressed sand, it then macerates down into 9 dust, as there is no compressed dust block. The recipe duration is simply 9 times that of the current recipe duration.