### PR TITLE
Remove the hidden GTCE block variants of Ender IO from oredict

### DIFF
--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -60,9 +60,34 @@ var blocksDisabled as IItemStack[][IOreDictEntry] = {
 		<actuallyadditions:block_misc:5>
 	],
 
+	#blockConductiveIron
+	<ore:blockConductiveIron> : [
+		<gregtech:compressed_16:15>
+	],
+
+	#blockDarkSteel
+	<ore:blockDarkSteel> : [
+		<gregtech:compressed_17:3>
+	],
+
 	#blockElectrum
 	<ore:blockElectrum> : [
 		<thermalfoundation:storage_alloy:1>
+	],
+
+	#blockElectricalSteel
+	<ore:blockElectricalSteel> : [
+		<gregtech:compressed_17:4>
+	],
+
+	#blockEndSteel
+	<ore:blockEndSteel> : [
+		<gregtech:compressed_17:10>
+	],
+
+	#blockEnergeticAlloy
+	<ore:blockEnergeticAlloy> : [
+		<gregtech:compressed_17>
 	],
 
 	#blockGraphite
@@ -129,6 +154,11 @@ var blocksDisabled as IItemStack[][IOreDictEntry] = {
 		<gregtech:compressed_2:7>
 	],
 
+	#blockPulsatingIron
+	<ore:blockPulsatingIron> : [
+		<gregtech:compressed_17:2>
+	],
+
 	#blockTin
 	<ore:blockTin> : [
 		<thermalfoundation:storage:1>,
@@ -139,6 +169,12 @@ var blocksDisabled as IItemStack[][IOreDictEntry] = {
 		<thermalfoundation:storage:1>,
 		<libvulpes:metal0:5>
 	],
+
+	#blockVibrantAlloy
+	<ore:blockVibrantAlloy> : [
+		<gregtech:compressed_17:1>
+	],
+
 	#blockTitanium
 	<ore:blockTitanium> : [
 		<libvulpes:metal0:7>


### PR DESCRIPTION
This prevents them from populating the Pattern recipes when used for Applied Energistics Patterns in Processing recipes that use the blocks, such as the cutting saw. These blocks are already hidden and mostly uncraftable, so removing them from the oredict poses little issue. This issue does not occur for the Thermal Blocks, as there is no Relevant machine processing recipe that uses the blocks, like the cutting saw recipe, Just recipes for fluid extraction and pulverization.

A similar reasoning is applied for not removing the GTCE variants of the Ender IO nuggets, there is simply not a relevant processing recipe where the conflict would matter