### PR TITLE
Add GT recipes for Solidified Experience

### DIFF
--- a/overrides/scripts/Microverse.zs
+++ b/overrides/scripts/Microverse.zs
@@ -447,7 +447,9 @@ makeShaped("of_aa_block_xp_solidifier", <actuallyadditions:block_xp_solidifier>,
 	  B : <gregtech:machine:322> }
 );
 <actuallyadditions:item_solidified_experience>.addTooltip(
-	format.green("Can be made in an Experience Solidifier."));
+	format.green("Drops from monsters, and can be made in"));
+<actuallyadditions:item_solidified_experience>.addTooltip(
+	format.green("a Fluid Solidifier or Experience Solidifier."));
 
 // Solidified Experience
 solidifier.recipeBuilder()

--- a/overrides/scripts/Microverse.zs
+++ b/overrides/scripts/Microverse.zs
@@ -449,6 +449,17 @@ makeShaped("of_aa_block_xp_solidifier", <actuallyadditions:block_xp_solidifier>,
 <actuallyadditions:item_solidified_experience>.addTooltip(
 	format.green("Can be made in an Experience Solidifier."));
 
+// Solidified Experience
+solidifier.recipeBuilder()
+    .fluidInputs([<liquid:xpjuice> * 160])
+    .notConsumable(<gregtech:meta_item_1:32307>)
+    .outputs(<actuallyadditions:item_solidified_experience>)
+    .duration(500).EUt(16).buildAndRegister();
+
+fluid_extractor.recipeBuilder()
+	.inputs(<actuallyadditions:item_solidified_experience>)
+	.fluidOutputs(<liquid:xpjuice> * 160)
+	.duration(80).EUt(32).buildAndRegister();
 
 <contenttweaker:tierfourship>.addTooltip(format.white(
 	format.italic("Harvests ultra cold materials from the deepest parts of empty space.")));


### PR DESCRIPTION
Adds a Fluid Extractor recipe to convert Solidified Experience into 160mb Liquid XP.
Adds a Fluid Solidifier recipe to convert 160mb Liquid XP (ball mold) into Solidified Experience.

Because Experience Solidifiers from ActAdd cannot be automated.