### PR TITLE
Switch Extended Crafting for the Forked version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -591,7 +591,7 @@
       "required": true
     },
     {
-      "projectID": 268387,
+      "projectID": 398267,
       "fileID": 3049327,
       "required": true
     },

--- a/manifest.json
+++ b/manifest.json
@@ -592,7 +592,7 @@
     },
     {
       "projectID": 268387,
-      "fileID": 2777071,
+      "fileID": 3049327,
       "required": true
     },
     {

--- a/overrides/config/extendedcrafting.cfg
+++ b/overrides/config/extendedcrafting.cfg
@@ -7,6 +7,9 @@
 ##########################################################################################################
 
 automation_interface {
+    # Should the Automation Interface accept GTEU? [default: false]
+    B:accept_gteu=false
+
     # Should the Automation Interface be enabled? [default: true]
     B:enabled=true
 
@@ -28,6 +31,9 @@ automation_interface {
 ##########################################################################################################
 
 combination_crafting {
+    # Should the Crafting Core accept GTEU? [default: false]
+    B:accept_gteu=false
+
     # Should the Crafting Core and Pedestal be enabled? [default: true]
     B:enabled=true
 
@@ -76,12 +82,27 @@ general {
 
 
 ##########################################################################################################
+# gregtech
+#--------------------------------------------------------------------------------------------------------#
+# Settings for GregTech compatibility.
+##########################################################################################################
+
+gregtech {
+    # How much RF should one GTEU be handled as? [range: 1 ~ 2147483647, default: 4]
+    I:conversion=4
+}
+
+
+##########################################################################################################
 # quantum_compression
 #--------------------------------------------------------------------------------------------------------#
 # Settings for the Quantum Compressor.
 ##########################################################################################################
 
 quantum_compression {
+    # Should the Quantum Compressor accept GTEU? [default: false]
+    B:accept_gteu=false
+
     # Should the Quantum Compressor be enabled? [default: true]
     B:enabled=true
 

--- a/overrides/config/extendedcrafting.cfg
+++ b/overrides/config/extendedcrafting.cfg
@@ -8,7 +8,7 @@
 
 automation_interface {
     # Should the Automation Interface accept GTEU? [default: false]
-    B:accept_gteu=false
+    B:accept_gteu=true
 
     # Should the Automation Interface be enabled? [default: true]
     B:enabled=true
@@ -32,7 +32,7 @@ automation_interface {
 
 combination_crafting {
     # Should the Crafting Core accept GTEU? [default: false]
-    B:accept_gteu=false
+    B:accept_gteu=true
 
     # Should the Crafting Core and Pedestal be enabled? [default: true]
     B:enabled=true
@@ -101,7 +101,7 @@ gregtech {
 
 quantum_compression {
     # Should the Quantum Compressor accept GTEU? [default: false]
-    B:accept_gteu=false
+    B:accept_gteu=true
 
     # Should the Quantum Compressor be enabled? [default: true]
     B:enabled=true


### PR DESCRIPTION
Switched Extended Crafting for our forked version. This fork fixes the Automation Interface dupe bug, introduces the possibility of machines being powered via GTEU, and implements CraftTweaker functions in a better method. No items stored in tables are lost when updating.

Closes #537 