### PR TITLE
Allow for all of the chisel space blocks in Microverse Projectors.

### DIFF
--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -26705,7 +26705,7 @@
             "2:10": {
               "Count:3": 26,
               "Damage:2": 3,
-              "OreDict:8": "",
+              "OreDict:8": "questbookSpace",
               "id:8": "chisel:diamond"
             },
             "3:10": {
@@ -26996,7 +26996,7 @@
             "1:10": {
               "Count:3": 248,
               "Damage:2": 3,
-              "OreDict:8": "",
+              "OreDict:8": "questbookSpace",
               "id:8": "chisel:diamond"
             },
             "2:10": {

--- a/overrides/scripts/Multiblocks.zs
+++ b/overrides/scripts/Multiblocks.zs
@@ -282,6 +282,12 @@ function space(maxIron as int, maxGold as int) as IBlockMatcher {
             & maxOf("iron", maxIron));
 }
 
+<ore:questbookSpace>.add(<chisel:diamond:3>,
+                         <chisel:diamond:4>
+                         // including the other blocks may cause confusion,
+                         // so this feature will be kept secret
+                         );
+
 var infoBuilder = FactoryMultiblockShapeInfo.start()
     .aisle(
         "CCCCC",

--- a/overrides/scripts/Multiblocks.zs
+++ b/overrides/scripts/Multiblocks.zs
@@ -274,11 +274,11 @@ function maxOf(key as string, count as int) as IBlockMatcher {
 function space(maxIron as int, maxGold as int) as IBlockMatcher {
     return checkSpace(<metastate:chisel:diamond:3>, "purple") |
            checkSpace(<metastate:chisel:diamond:4>, "black") |
-           (checkSpace(<metastate:chisel:gold:11>, "purple") |
-            checkSpace(<metastate:chisel:gold:12>, "black")
+           ((checkSpace(<metastate:chisel:gold:11>, "purple") |
+             checkSpace(<metastate:chisel:gold:12>, "black"))
             & maxOf("gold", maxGold)) |
-           (checkSpace(<metastate:chisel:iron:11>, "purple") |
-            checkSpace(<metastate:chisel:iron:12>, "black")
+           ((checkSpace(<metastate:chisel:iron:11>, "purple") |
+             checkSpace(<metastate:chisel:iron:12>, "black"))
             & maxOf("iron", maxIron));
 }
 

--- a/overrides/scripts/Multiblocks.zs
+++ b/overrides/scripts/Multiblocks.zs
@@ -1,5 +1,6 @@
 import crafttweaker.world.IFacing;
 import crafttweaker.block.IBlock;
+import crafttweaker.block.IBlockState;
 import crafttweaker.item.IIngredient;
 import crafttweaker.item.IItemStack;
 
@@ -253,6 +254,74 @@ val small_microverse = Builder.start(loc, id)
 id += 1;
 loc = "medium_microverse";
 
+function checkSpace(blockState as IBlockState, color as string) as IBlockMatcher {
+    return blockState as IBlockMatcher & function(state as IBlockWorldState) as bool {
+        return state.matchContext.getOrPut("space", color) == color;
+    } as IBlockMatcher;
+}
+
+function maxOf(key as string, count as int) as IBlockMatcher {
+    return function(state as IBlockWorldState) as bool {
+        if state.matchContext.getInt(key) < count {
+            state.matchContext.increment(key, 1);
+            return true;
+        } else {
+            return false;
+        }
+    } as IBlockMatcher;
+}
+
+function space(maxIron as int, maxGold as int) as IBlockMatcher {
+    return checkSpace(<metastate:chisel:diamond:3>, "purple") |
+           checkSpace(<metastate:chisel:diamond:4>, "black") |
+           (checkSpace(<metastate:chisel:gold:11>, "purple") |
+            checkSpace(<metastate:chisel:gold:12>, "black")
+            & maxOf("gold", maxGold)) |
+           (checkSpace(<metastate:chisel:iron:11>, "purple") |
+            checkSpace(<metastate:chisel:iron:12>, "black")
+            & maxOf("iron", maxIron));
+}
+
+var infoBuilder = FactoryMultiblockShapeInfo.start()
+    .aisle(
+        "CCCCC",
+        "CGGGC",
+        "CGGGC",
+        "CGGGC",
+        "CCCCC")
+    .aisle(
+        "ICCCC",
+        "GDDDG",
+        "GDDDG",
+        "GDDDG",
+        "CVCVC")
+    .aisle(
+        "SCCC@",
+        "GDDDG",
+        "GD*DG",
+        "GDDDG",
+        "CCCCC")
+    .aisle(
+        "OCCCC",
+        "GDDDG",
+        "GDDDG",
+        "GDDDG",
+        "CVCVC")
+    .aisle(
+        "CCCCC",
+        "CGGGC",
+        "CGGGC",
+        "CGGGC",
+        "CCCCC")
+    .where('S', IBlockInfo.controller(loc))
+    .where('C', <contenttweaker:microverse_casing>)
+    .where('G', <metastate:extrautils2:ineffableglass:2>)
+    .where('V', <contenttweaker:microverse_vent>)
+    .where('*', <extendedcrafting:compressor>)
+    .where('@', MetaTileEntities.ENERGY_INPUT_HATCH[4], IFacing.east())
+    .where('I', MetaTileEntities.ITEM_IMPORT_BUS[1], IFacing.west())
+    .where('O', MetaTileEntities.ITEM_EXPORT_BUS[3], IFacing.west());
+
 val medium_microverse = Builder.start(loc, id)
     .withPattern(
         FactoryBlockPattern.start(RelativeDirection.RIGHT, RelativeDirection.DOWN, RelativeDirection.FRONT)
@@ -287,9 +356,9 @@ val medium_microverse = Builder.start(loc, id)
                     "CGGGC",
                     "CCCCC")
             .where('S', IBlockMatcher.controller(loc))
-            .where('D', <metastate:chisel:diamond:3>)
             .where('G', <metastate:extrautils2:ineffableglass:2>)
             .where('V', <contenttweaker:microverse_vent>)
+            .where('D', space(2, 4))
             .where('*', <extendedcrafting:compressor>)
             .whereOr('C', <contenttweaker:microverse_casing> as IBlock as IBlockMatcher,
                             IBlockMatcher.abilityPartPredicate(MultiblockAbility.INPUT_ENERGY,
@@ -303,48 +372,8 @@ val medium_microverse = Builder.start(loc, id)
             .setAmountAtLeast('#', 50)
             .where('#', <contenttweaker:microverse_casing>)
             .build())
-    .addDesign(
-        FactoryMultiblockShapeInfo.start()
-            .aisle(
-                    "CCCCC",
-                    "CGGGC",
-                    "CGGGC",
-                    "CGGGC",
-                    "CCCCC")
-            .aisle(
-                    "ICCCC",
-                    "GDDDG",
-                    "GDDDG",
-                    "GDDDG",
-                    "CVCVC")
-            .aisle(
-                    "SCCC@",
-                    "GDDDG",
-                    "GD*DG",
-                    "GDDDG",
-                    "CCCCC")
-            .aisle(
-                    "OCCCC",
-                    "GDDDG",
-                    "GDDDG",
-                    "GDDDG",
-                    "CVCVC")
-            .aisle(
-                    "CCCCC",
-                    "CGGGC",
-                    "CGGGC",
-                    "CGGGC",
-                    "CCCCC")
-            .where('S', IBlockInfo.controller(loc))
-            .where('C', <contenttweaker:microverse_casing>)
-            .where('G', <metastate:extrautils2:ineffableglass:2>)
-            .where('V', <contenttweaker:microverse_vent>)
-            .where('D', <metastate:chisel:diamond:3>)
-            .where('*', <extendedcrafting:compressor>)
-            .where('@', MetaTileEntities.ENERGY_INPUT_HATCH[4], IFacing.east())
-            .where('I', MetaTileEntities.ITEM_IMPORT_BUS[1], IFacing.west())
-            .where('O', MetaTileEntities.ITEM_EXPORT_BUS[3], IFacing.west())
-            .build())
+    .addDesign(infoBuilder.where('D', <metastate:chisel:diamond:3>).build())
+    .addDesign(infoBuilder.where('D', <metastate:chisel:diamond:4>).build())
     .withRecipeMap(
         FactoryRecipeMap.start(loc)
                         .minInputs(2)
@@ -358,106 +387,117 @@ val medium_microverse = Builder.start(loc, id)
 id += 1;
 loc = "large_microverse";
 
+infoBuilder = FactoryMultiblockShapeInfo.start()
+    .aisle(
+        "         ",
+        "         ",
+        "  CCCCC  ",
+        "  CGGGC  ",
+        "  CGGGC  ",
+        "  CGGGC  ",
+        "  CCCCC  ",
+        "         ",
+        "         ")
+    .aisle(
+        "         ",
+        "  CGGGC  ",
+        " CDDDDDC ",
+        " GDDDDDG ",
+        " GDDDDDG ",
+        " GDDDDDG ",
+        " CDDDDDC ",
+        "  CGGGC  ",
+        "         ")
+    .aisle(
+        "  CCCCC  ",
+        " CDDDDDC ",
+        "CDDDDDDDC",
+        "CDDDDDDDC",
+        "CDDDDDDDC",
+        "CDDDDDDDC",
+        "CDDDDDDDC",
+        " CDDDDDC ",
+        "  CCCCC  ")
+    .aisle(
+        "  ICCCC  ",
+        " GDDDDDG ",
+        "CDDDDDDDC",
+        "GDDQQQDDG",
+        "GDDQQQDDG",
+        "GDDQQQDDG",
+        "CDDDDDDDC",
+        " GDDDDDG ",
+        "  CVCVC  ")
+    .aisle(
+        "  SCCCE  ",
+        " GDDDDDG ",
+        "CDDDDDDDC",
+        "GDDQQQDDG",
+        "GDDQQQDDG",
+        "GDDQQQDDG",
+        "CDDDDDDDC",
+        " GDDDDDG ",
+        "  CCCCC  ")
+    .aisle(
+        "  OCCCC  ",
+        " GDDDDDG ",
+        "CDDDDDDDC",
+        "GDDQQQDDG",
+        "GDDQQQDDG",
+        "GDDQQQDDG",
+        "CDDDDDDDC",
+        " GDDDDDG ",
+        "  CVCVC  ")
+    .aisle(
+        "  CCCCC  ",
+        " CDDDDDC ",
+        "CDDDDDDDC",
+        "CDDDDDDDC",
+        "CDDDDDDDC",
+        "CDDDDDDDC",
+        "CDDDDDDDC",
+        " CDDDDDC ",
+        "  CCCCC  ")
+    .aisle(
+        "         ",
+        "  CGGGC  ",
+        " CDDDDDC ",
+        " GDDDDDG ",
+        " GDDDDDG ",
+        " GDDDDDG ",
+        " CDDDDDC ",
+        "  CGGGC  ",
+        "         ")
+    .aisle(
+        "         ",
+        "         ",
+        "  CCCCC  ",
+        "  CGGGC  ",
+        "  CGGGC  ",
+        "  CGGGC  ",
+        "  CCCCC  ",
+        "         ",
+        "         ")
+    .where('S', IBlockInfo.controller(loc))
+    .where('C', <contenttweaker:microverse_casing>)
+    .where('V', <contenttweaker:microverse_vent>)
+    .where('G', <metastate:extrautils2:ineffableglass:2>)
+    .where('Q', <extendedcrafting:compressor>)
+    .where('I', MetaTileEntities.ITEM_IMPORT_BUS[3], IFacing.west())
+    .where('E', MetaTileEntities.ENERGY_INPUT_HATCH[8], IFacing.east())
+    .where('O', MetaTileEntities.ITEM_EXPORT_BUS[4], IFacing.west());
+
 val large_microverse = Builder.start(loc, id)
     .withPattern(
         FactoryBlockPattern.start(RelativeDirection.RIGHT, RelativeDirection.BACK, RelativeDirection.UP)
-        .aisle(
-            "         ",
-            "         ",
-            "  CCCCC  ",
-            "  CCCCC  ",
-            "  CCCCC  ",
-            "  CCCCC  ",
-            "  CCSCC  ",
-            "         ",
-            "         ")
-        .aisle(
-            "         ",
-            "  CGGGC  ",
-            " CDDDDDC ",
-            " GDDDDDG ",
-            " GDDDDDG ",
-            " GDDDDDG ",
-            " CDDDDDC ",
-            "  CGGGC  ",
-            "         ")
-        .aisle(
-            "  CCCCC  ",
-            " CDDDDDC ",
-            "CDDDDDDDC",
-            "CDDDDDDDC",
-            "CDDDDDDDC",
-            "CDDDDDDDC",
-            "CDDDDDDDC",
-            " CDDDDDC ",
-            "  CCCCC  ")
-        .aisleRepeatable(3,
-            "  CGGGC  ",
-            " GDDDDDG ",
-            "CDDDDDDDC",
-            "GDDQQQDDG",
-            "GDDQQQDDG",
-            "GDDQQQDDG",
-            "CDDDDDDDC",
-            " GDDDDDG ",
-            "  CGGGC  ")
-        .aisle(
-            "  CCCCC  ",
-            " CDDDDDC ",
-            "CDDDDDDDC",
-            "CDDDDDDDC",
-            "CDDDDDDDC",
-            "CDDDDDDDC",
-            "CDDDDDDDC",
-            " CDDDDDC ",
-            "  CCCCC  ")
-        .aisle(
-            "         ",
-            "  CGGGC  ",
-            " CDDDDDC ",
-            " GDDDDDG ",
-            " GDDDDDG ",
-            " GDDDDDG ",
-            " CDDDDDC ",
-            "  CGGGC  ",
-            "         ")
-        .aisle(
-            "         ",
-            "         ",
-            "  CCCCC  ",
-            "  CVCVC  ",
-            "  CCCCC  ",
-            "  CVCVC  ",
-            "  CCCCC  ",
-            "         ",
-            "         ")
-        .where('S', IBlockMatcher.controller(loc))
-        .where('V', <contenttweaker:microverse_vent>)
-        .where('G', <metastate:extrautils2:ineffableglass:2>)
-        .where('D', <metastate:chisel:diamond:3>)
-        .where('Q', <extendedcrafting:compressor>)
-        .whereOr('C', <contenttweaker:microverse_casing> as IBlock as IBlockMatcher,
-                        IBlockMatcher.abilityPartPredicate(MultiblockAbility.IMPORT_ITEMS,
-                                                            MultiblockAbility.EXPORT_ITEMS,
-                                                            MultiblockAbility.INPUT_ENERGY))
-
-        .setAmountAtMost('@', 2)
-        .where('@', IBlockMatcher.abilityPartPredicate(MultiblockAbility.INPUT_ENERGY))
-        .setAmountAtLeast('I', 1)
-        .where('I', IBlockMatcher.abilityPartPredicate(MultiblockAbility.EXPORT_ITEMS))
-        .setAmountAtLeast('#', 125)
-        .where('#', <contenttweaker:microverse_casing>)
-        .build())
-    .addDesign(
-        FactoryMultiblockShapeInfo.start()
             .aisle(
                 "         ",
                 "         ",
                 "  CCCCC  ",
-                "  CGGGC  ",
-                "  CGGGC  ",
-                "  CGGGC  ",
                 "  CCCCC  ",
+                "  CCCCC  ",
+                "  CCCCC  ",
+                "  CCSCC  ",
                 "         ",
                 "         ")
             .aisle(
@@ -480,8 +520,8 @@ val large_microverse = Builder.start(loc, id)
                 "CDDDDDDDC",
                 " CDDDDDC ",
                 "  CCCCC  ")
-            .aisle(
-                "  ICCCC  ",
+            .aisleRepeatable(3,
+                "  CGGGC  ",
                 " GDDDDDG ",
                 "CDDDDDDDC",
                 "GDDQQQDDG",
@@ -489,27 +529,7 @@ val large_microverse = Builder.start(loc, id)
                 "GDDQQQDDG",
                 "CDDDDDDDC",
                 " GDDDDDG ",
-                "  CVCVC  ")
-            .aisle(
-                "  SCCCE  ",
-                " GDDDDDG ",
-                "CDDDDDDDC",
-                "GDDQQQDDG",
-                "GDDQQQDDG",
-                "GDDQQQDDG",
-                "CDDDDDDDC",
-                " GDDDDDG ",
-                "  CCCCC  ")
-            .aisle(
-                "  OCCCC  ",
-                " GDDDDDG ",
-                "CDDDDDDDC",
-                "GDDQQQDDG",
-                "GDDQQQDDG",
-                "GDDQQQDDG",
-                "CDDDDDDDC",
-                " GDDDDDG ",
-                "  CVCVC  ")
+                "  CGGGC  ")
             .aisle(
                 "  CCCCC  ",
                 " CDDDDDC ",
@@ -534,22 +554,31 @@ val large_microverse = Builder.start(loc, id)
                 "         ",
                 "         ",
                 "  CCCCC  ",
-                "  CGGGC  ",
-                "  CGGGC  ",
-                "  CGGGC  ",
+                "  CVCVC  ",
+                "  CCCCC  ",
+                "  CVCVC  ",
                 "  CCCCC  ",
                 "         ",
                 "         ")
-            .where('S', IBlockInfo.controller(loc))
-            .where('C', <contenttweaker:microverse_casing>)
+            .where('S', IBlockMatcher.controller(loc))
             .where('V', <contenttweaker:microverse_vent>)
             .where('G', <metastate:extrautils2:ineffableglass:2>)
-            .where('D', <metastate:chisel:diamond:3>)
+            .where('D', space(8, 16))
             .where('Q', <extendedcrafting:compressor>)
-            .where('I', MetaTileEntities.ITEM_IMPORT_BUS[3], IFacing.west())
-            .where('E', MetaTileEntities.ENERGY_INPUT_HATCH[8], IFacing.east())
-            .where('O', MetaTileEntities.ITEM_EXPORT_BUS[4], IFacing.west())
+            .whereOr('C', <contenttweaker:microverse_casing> as IBlock as IBlockMatcher,
+                            IBlockMatcher.abilityPartPredicate(MultiblockAbility.IMPORT_ITEMS,
+                                                                MultiblockAbility.EXPORT_ITEMS,
+                                                                MultiblockAbility.INPUT_ENERGY))
+
+            .setAmountAtMost('@', 2)
+            .where('@', IBlockMatcher.abilityPartPredicate(MultiblockAbility.INPUT_ENERGY))
+            .setAmountAtLeast('I', 1)
+            .where('I', IBlockMatcher.abilityPartPredicate(MultiblockAbility.EXPORT_ITEMS))
+            .setAmountAtLeast('#', 125)
+            .where('#', <contenttweaker:microverse_casing>)
             .build())
+    .addDesign(infoBuilder.where('D', <metastate:chisel:diamond:3>).build())
+    .addDesign(infoBuilder.where('D', <metastate:chisel:diamond:4>).build())
     .withRecipeMap(
         FactoryRecipeMap.start(loc)
                         .minInputs(2)


### PR DESCRIPTION
There are some rules, however:
- No mixing purple and black space blocks.
- At most 2 and 8 iron blocks in the medium and large projectors respectively.
- At most 4 and 16 gold blocks in the medium and large projectors respectively.

Closes #618 

Questbook has been updated to accept both black and purple diamond space blocks.