### PR TITLE
Add generation for alternative stone variants (marble/basalt/etc)

### DIFF
--- a/overrides/config/gregtech/worldgen/overworld/basalt_sphere.json
+++ b/overrides/config/gregtech/worldgen/overworld/basalt_sphere.json
@@ -1,6 +1,5 @@
 {
   "weight": 120,
-  "priority": 100,
   "density": 1.0,
   "min_height": 10,
   "dimension_filter": ["name:*(overworld|lostcities)"],

--- a/overrides/config/gregtech/worldgen/overworld/basalt_sphere.json
+++ b/overrides/config/gregtech/worldgen/overworld/basalt_sphere.json
@@ -1,0 +1,29 @@
+{
+  "weight": 120,
+  "priority": 100,
+  "density": 1.0,
+  "min_height": 10,
+  "dimension_filter": ["name:*(overworld|lostcities)"],
+  "count_as_vein": false,
+
+  "generator": {
+    "type": "sphere",
+    "radius": [10, 20]
+  },
+  "filler": {
+    "type": "ignore_bedrock",
+    "value": {
+      "type": "weight_random",
+      "values": [
+        {
+          "weight": 100,
+          "value": {
+            "block": "gregtech:mineral",
+            "variant": "basalt",
+            "chiseling_variant": "normal"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/overrides/config/gregtech/worldgen/overworld/black_granite_sphere.json
+++ b/overrides/config/gregtech/worldgen/overworld/black_granite_sphere.json
@@ -1,0 +1,29 @@
+{
+  "weight": 90,
+  "priority": 100,
+  "density": 1.0,
+  "min_height": 10,
+  "dimension_filter": ["name:*(overworld|lostcities)"],
+  "count_as_vein": false,
+
+  "generator": {
+    "type": "sphere",
+    "radius": [10, 20]
+  },
+  "filler": {
+    "type": "ignore_bedrock",
+    "value": {
+      "type": "weight_random",
+      "values": [
+        {
+          "weight": 100,
+          "value": {
+            "block": "gregtech:granite",
+            "variant": "black_granite",
+            "chiseling_variant": "normal"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/overrides/config/gregtech/worldgen/overworld/black_granite_sphere.json
+++ b/overrides/config/gregtech/worldgen/overworld/black_granite_sphere.json
@@ -1,6 +1,5 @@
 {
   "weight": 90,
-  "priority": 100,
   "density": 1.0,
   "min_height": 10,
   "dimension_filter": ["name:*(overworld|lostcities)"],

--- a/overrides/config/gregtech/worldgen/overworld/marble_sphere.json
+++ b/overrides/config/gregtech/worldgen/overworld/marble_sphere.json
@@ -1,0 +1,29 @@
+{
+  "weight": 120,
+  "priority": 100,
+  "density": 1.0,
+  "min_height": 10,
+  "dimension_filter": ["name:*(overworld|lostcities)"],
+  "count_as_vein": false,
+
+  "generator": {
+    "type": "sphere",
+    "radius": [10, 20]
+  },
+  "filler": {
+    "type": "ignore_bedrock",
+    "value": {
+      "type": "weight_random",
+      "values": [
+        {
+          "weight": 100,
+          "value": {
+            "block": "gregtech:mineral",
+            "variant": "marble",
+            "chiseling_variant": "normal"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/overrides/config/gregtech/worldgen/overworld/marble_sphere.json
+++ b/overrides/config/gregtech/worldgen/overworld/marble_sphere.json
@@ -1,6 +1,5 @@
 {
   "weight": 120,
-  "priority": 100,
   "density": 1.0,
   "min_height": 10,
   "dimension_filter": ["name:*(overworld|lostcities)"],

--- a/overrides/config/gregtech/worldgen/overworld/red_granite_sphere.json
+++ b/overrides/config/gregtech/worldgen/overworld/red_granite_sphere.json
@@ -1,0 +1,29 @@
+{
+  "weight": 90,
+  "priority": 100,
+  "density": 1.0,
+  "min_height": 10,
+  "dimension_filter": ["name:*(overworld|lostcities)"],
+  "count_as_vein": false,
+
+  "generator": {
+    "type": "sphere",
+    "radius": [10, 20]
+  },
+  "filler": {
+    "type": "ignore_bedrock",
+    "value": {
+      "type": "weight_random",
+      "values": [
+        {
+          "weight": 100,
+          "value": {
+            "block": "gregtech:granite",
+            "variant": "red_granite",
+            "chiseling_variant": "normal"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/overrides/config/gregtech/worldgen/overworld/red_granite_sphere.json
+++ b/overrides/config/gregtech/worldgen/overworld/red_granite_sphere.json
@@ -1,6 +1,5 @@
 {
   "weight": 90,
-  "priority": 100,
   "density": 1.0,
   "min_height": 10,
   "dimension_filter": ["name:*(overworld|lostcities)"],

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -1167,18 +1167,10 @@ for oreDictEntry, items in miscDisabled {
 <ore:blockWarpCoreRim>.add(<gregtech:compressed_3:10>);
 
 //GTCE Marble
-<ore:stoneMarble>.add(<gregtech:mineral>);
 mods.chisel.Carving.addVariation("marble", <gregtech:mineral>);
 
 //GTCE Basalt
-<ore:stoneBasalt>.add(<gregtech:mineral:2>);
 mods.chisel.Carving.addVariation("basalt", <gregtech:mineral:2>);
-
-//GTCE Black Granite
-<ore:stoneGraniteBlack>.add(<gregtech:granite>);
-
-//GTCE Red Granite
-<ore:stoneGraniteRed>.add(<gregtech:granite:1>);
 
 //Create Universal GTCE Oredict for tools that can be used to reference by oredict and encapsulates all tools.
 //Works for any material tool, any damage tool, electric or non-electric

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -1166,6 +1166,20 @@ for oreDictEntry, items in miscDisabled {
 
 <ore:blockWarpCoreRim>.add(<gregtech:compressed_3:10>);
 
+//GTCE Marble
+<ore:stoneMarble>.add(<gregtech:mineral>);
+mods.chisel.Carving.addVariation("marble", <gregtech:mineral>);
+
+//GTCE Basalt
+<ore:stoneBasalt>.add(<gregtech:mineral:2>);
+mods.chisel.Carving.addVariation("basalt", <gregtech:mineral:2>);
+
+//GTCE Black Granite
+<ore:stoneGraniteBlack>.add(<gregtech:granite>);
+
+//GTCE Red Granite
+<ore:stoneGraniteRed>.add(<gregtech:granite:1>);
+
 //Create Universal GTCE Oredict for tools that can be used to reference by oredict and encapsulates all tools.
 //Works for any material tool, any damage tool, electric or non-electric
 


### PR DESCRIPTION
Supersedes #571 

Adds generation for the stone variants: marble, basalt, red granite, black granite.
Generation files are copied from default GTCE, and modified for the pack to include lost cities dimension generation like all other ore veins. These generations are verified to work.


As a side effect of enabling these blocks:
Marble dust is obtainable and electrolyzes into magnesium and calcite
Basalt dust is obtainable and electrolyzes into Olivine, Calcite, Flint, and Dark Ash
Red Granite dust is obtainable and electrolyzes into Aluminum, Potassium-Feldspar, and Oxygen
Black Granite dust is obtainable and electrolyzes into Silicon Dioxide and Biotite

In addition, adds the marble and basalt into the chisel categories for marble and basalt respectively.

Also, as a consequence, I have seen ores generating in the marble blocks. I have not seen generation in black or red granite, but I did not check extensively for it. This might be able to be disabled, if desired, but I would have to look into it.