### PR TITLE
Rebalance Sapphire ore in Microminers

### DIFF
--- a/overrides/scripts/Multiblocks.zs
+++ b/overrides/scripts/Multiblocks.zs
@@ -1503,10 +1503,9 @@ small_microverse.recipeMap
              <gregtech:ore_tetrahedrite_0:6> * 64,
              <gregtech:ore_cassiterite_0:6> * 64,
              <gregtech:ore_tin_0:6> * 64,
+             <gregtech:ore_redstone_0:6> * 64,
              <gregtech:ore_certus_quartz_0:6> * 64,
-             <gregtech:ore_almandine_0:6> * 64,
-             <gregtech:ore_sapphire_0:6> * 64,
-             <gregtech:ore_sapphire_0:6> * 64)
+             <gregtech:ore_almandine_0:6> * 64)
     .buildAndRegister();
 
 // Tier 4: Signalum Microminer - Mission 1: Dense Oil / Infinity Blocks

--- a/overrides/scripts/Multiblocks.zs
+++ b/overrides/scripts/Multiblocks.zs
@@ -1478,7 +1478,7 @@ small_microverse.recipeMap
              <gregtech:meta_item_2:25154> * 16,
              <gregtech:meta_item_2:25154> * 16,
              <gregtech:meta_item_2:25154> * 16,
-             <gregtech:ore_almandine_0:6> * 64,
+             <gregtech:ore_sapphire_0:6> * 64,
              <gregtech:ore_gold_0:6> * 64,
              <gregtech:ore_silver_0:6> * 64)
     .buildAndRegister();
@@ -1503,8 +1503,9 @@ small_microverse.recipeMap
              <gregtech:ore_tetrahedrite_0:6> * 64,
              <gregtech:ore_cassiterite_0:6> * 64,
              <gregtech:ore_tin_0:6> * 64,
-             <gregtech:ore_redstone_0:6> * 64,
              <gregtech:ore_certus_quartz_0:6> * 64,
+             <gregtech:ore_almandine_0:6> * 64,
+             <gregtech:ore_sapphire_0:6> * 64,
              <gregtech:ore_sapphire_0:6> * 64)
     .buildAndRegister();
 


### PR DESCRIPTION
Rebalances the Sapphire and Almandine amounts and availability in Microminer missions, namely because Almandine gives 12 crushed ores, but the Sapphire only gives 2, making Sapphire much more rare when both are needed for empowered blocks.

1: Replaces the Almandine in the Exquisite Gems T3 mission with Sapphire
2: Adds the Almandine to the T3 midgame ores mission
3: Replaces one instance of Redstone ore in the T3 midgame ores mission with Sapphire.