### PR TITLE
Gregtech update

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -422,7 +422,7 @@
     },
     {
       "projectID": 293327,
-      "fileID": 3167654,
+      "fileID": 3182667,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -422,7 +422,7 @@
     },
     {
       "projectID": 293327,
-      "fileID": 3182667,
+      "fileID": 3198554,
       "required": true
     },
     {

--- a/overrides/scripts/BlastFurnace.zs
+++ b/overrides/scripts/BlastFurnace.zs
@@ -122,7 +122,7 @@ blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2133>], [null]).remove();
 furnace.addRecipe(<gregtech:meta_item_1:10133>, <gregtech:meta_item_1:2133>, 0.0);
 blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:10044> * 4,<gregtech:meta_item_1:10016>]).outputs([<gregtech:meta_item_1:11133> * 5]).property("temperature", 2100).duration(800).EUt(480).buildAndRegister();
 
-//Titanium [tier 4] TODO: Remove
+//Titanium [tier 4]
 blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2072>], [null]).remove();
 
 

--- a/overrides/scripts/BlastFurnace.zs
+++ b/overrides/scripts/BlastFurnace.zs
@@ -122,10 +122,9 @@ blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2133>], [null]).remove();
 furnace.addRecipe(<gregtech:meta_item_1:10133>, <gregtech:meta_item_1:2133>, 0.0);
 blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:10044> * 4,<gregtech:meta_item_1:10016>]).outputs([<gregtech:meta_item_1:11133> * 5]).property("temperature", 2100).duration(800).EUt(480).buildAndRegister();
 
-//Titanium [tier 4]
-blast_furnace.findRecipe(480, [<gregtech:meta_item_1:2038> * 2], [<liquid:titanium_tetrachloride> * 1000]).remove();
-blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2072>], [null]).remove();	
-blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:2038> * 2]).fluidInputs([<liquid:titanium_tetrachloride> * 1000]).outputs([<gregtech:meta_item_1:11072>,<gregtech:meta_item_1:2125> * 6]).property("temperature", 2100).duration(800).EUt(480).buildAndRegister();
+//Titanium [tier 4] TODO: Remove
+blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2072>], [null]).remove();
+
 
 //Yttrium [tier 4]
 blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2078>], [null]).remove();	

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -332,9 +332,6 @@ reactor.recipeBuilder()
 //Remove other recipe for Dimethylhydrazine
 reactor.findRecipe(480, [null], [<liquid:methanol> * 2000, <liquid:ammonia> * 2000, <liquid:hypochlorous_acid> * 1000]).remove();
 
-mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:466>);
-mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:1466>);
-mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:2466>);
 mods.jei.JEI.removeAndHide(<gregtech:compressed_16:13>);
 mods.jei.JEI.removeAndHide(<appliedenergistics2:facade>.withTag({damage: 13, item: "gregtech:compressed_16"}));
 

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -318,7 +318,7 @@ mixer.findRecipe(8, [<gregtech:meta_item_1:2184> * 3,<gregtech:meta_item_1:2229>
 reactor.findRecipe(384, [<gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000]).remove();
 reactor.recipeBuilder().notConsumable(<gregtech:meta_item_1:32766>.withTag({Configuration: 1})).fluidInputs(<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000).fluidOutputs(<liquid:ammonia> * 4000).EUt(100).duration(320).buildAndRegister();
 
-//Ammonia Recipe: Changes the EU/t and the Output amount
+//Ammonia Recipe: Changes the EU/t
 reactor.findRecipe(384, [<gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000]).remove();
 reactor.recipeBuilder()
 	.notConsumable(<gregtech:meta_item_1:32766>.withTag({Configuration: 1}))

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -314,14 +314,6 @@ assembler.findRecipe(2, [<minecraft:blaze_powder>,<minecraft:ender_pearl>], [nul
 assembler.findRecipe(2, [<minecraft:ender_pearl> * 6,<minecraft:blaze_rod>], [null]).remove();
 mixer.findRecipe(8, [<gregtech:meta_item_1:2184> * 3,<gregtech:meta_item_1:2229>,<gregtech:meta_item_1:2044>], [null]).remove();
 
-// Magnesium Chloride decomposition
-reactor.findRecipe(240, [<gregtech:meta_item_1:2125> * 2,<gregtech:meta_item_1:2063>], [null]).remove();
-electrolyzer.recipeBuilder()
-    .inputs([<gregtech:meta_item_1:2125>*3])
-    .outputs([<gregtech:meta_item_1:2038>])
-    .fluidOutputs([<liquid:chlorine>*2000])
-    .duration(720).EUt(30).buildAndRegister();
-
 reactor.findRecipe(388, [<gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:oxygen> * 500, <liquid:hydrogen> * 3000, <liquid:nitrogen_dioxide> * 1000]).remove();
 
 

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -336,9 +336,9 @@ reactor.findRecipe(480, [null], [<liquid:methanol> * 2000, <liquid:ammonia> * 20
 reactor.findRecipe(30, [<gregtech:meta_item_1:2050>], [<liquid:oxygen> * 2500, <liquid:water> * 1500]).remove();
 
 reactor.recipeBuilder()
-	.inputs(<gregtech:meta_item_1:2050>)
-	.fluidInputs([<liquid:oxygen> * 4000, <liquid:hydrogen> * 4000])
-	.fluidOutputs(<liquid:phosphoric_acid> * 1000)
+	.inputs(<gregtech:meta_item_1:2050> * 2)
+	.fluidInputs([<liquid:oxygen> * 5000, <liquid:water> * 3000])
+	.fluidOutputs(<liquid:phosphoric_acid> * 2000)
 	.duration(320).EUt(16).buildAndRegister();
 
 mods.jei.JEI.removeAndHide(<gregtech:compressed_16:13>);

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -314,8 +314,6 @@ assembler.findRecipe(2, [<minecraft:blaze_powder>,<minecraft:ender_pearl>], [nul
 assembler.findRecipe(2, [<minecraft:ender_pearl> * 6,<minecraft:blaze_rod>], [null]).remove();
 mixer.findRecipe(8, [<gregtech:meta_item_1:2184> * 3,<gregtech:meta_item_1:2229>,<gregtech:meta_item_1:2044>], [null]).remove();
 
-reactor.findRecipe(388, [<gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:oxygen> * 500, <liquid:hydrogen> * 3000, <liquid:nitrogen_dioxide> * 1000]).remove();
-
 
 reactor.findRecipe(384, [<gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000]).remove();
 reactor.recipeBuilder().notConsumable(<gregtech:meta_item_1:32766>.withTag({Configuration: 1})).fluidInputs(<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000).fluidOutputs(<liquid:ammonia> * 4000).EUt(100).duration(320).buildAndRegister();

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -322,10 +322,6 @@ reactor.findRecipe(480, [null], [<liquid:chloramine> * 1000, <liquid:dimethylami
 reactor.findRecipe(480, [null], [<liquid:methanol> * 2000, <liquid:ammonia> * 1000, <liquid:hypochlorous_acid> * 1000]).remove();
 reactor.recipeBuilder().fluidInputs(<liquid:chloramine> * 1000, <liquid:dimethylamine> * 1000).fluidOutputs(<liquid:dimethylhidrazine> * 1000,<liquid:diluted_hydrochloric_acid> * 1000).EUt(120).duration(960).buildAndRegister();
 
-//Remove phosphorus pentoxide, not used anywhere aside from duping phosphorus
-reactor.findRecipe(30, [<gregtech:meta_item_1:2466>], [<liquid:water> * 6000]).remove();
-reactor.findRecipe(30, [<gregtech:meta_item_1:2050> * 4], [<liquid:oxygen> * 10000]).remove();
-
 mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:466>);
 mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:1466>);
 mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:2466>);

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -314,10 +314,6 @@ assembler.findRecipe(2, [<minecraft:blaze_powder>,<minecraft:ender_pearl>], [nul
 assembler.findRecipe(2, [<minecraft:ender_pearl> * 6,<minecraft:blaze_rod>], [null]).remove();
 mixer.findRecipe(8, [<gregtech:meta_item_1:2184> * 3,<gregtech:meta_item_1:2229>,<gregtech:meta_item_1:2044>], [null]).remove();
 
-
-reactor.findRecipe(384, [<gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000]).remove();
-reactor.recipeBuilder().notConsumable(<gregtech:meta_item_1:32766>.withTag({Configuration: 1})).fluidInputs(<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000).fluidOutputs(<liquid:ammonia> * 4000).EUt(100).duration(320).buildAndRegister();
-
 //Ammonia Recipe: Changes the EU/t
 reactor.findRecipe(384, [<gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000]).remove();
 reactor.recipeBuilder()
@@ -330,7 +326,8 @@ reactor.recipeBuilder()
 reactor.findRecipe(480, [null], [<liquid:chloramine> * 1000, <liquid:dimethylamine> * 1000]).remove();
 reactor.recipeBuilder()
 	.fluidInputs(<liquid:chloramine> * 1000, <liquid:dimethylamine> * 1000)
-	.fluidOutputs(<liquid:dimethylhidrazine> * 1000,<liquid:hydrochloric_acid> * 1000).EUt(120).duration(960).buildAndRegister();
+	.fluidOutputs(<liquid:dimethylhidrazine> * 1000,<liquid:hydrochloric_acid> * 1000)
+	.EUt(120).duration(960).buildAndRegister();
 
 //Remove other recipe for Dimethylhydrazine
 reactor.findRecipe(480, [null], [<liquid:methanol> * 2000, <liquid:ammonia> * 2000, <liquid:hypochlorous_acid> * 1000]).remove();

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -332,6 +332,15 @@ reactor.recipeBuilder()
 //Remove other recipe for Dimethylhydrazine
 reactor.findRecipe(480, [null], [<liquid:methanol> * 2000, <liquid:ammonia> * 2000, <liquid:hypochlorous_acid> * 1000]).remove();
 
+//Phosphoric Acid, fix mol amounts
+reactor.findRecipe(30, [<gregtech:meta_item_1:2050>], [<liquid:oxygen> * 2500, <liquid:water> * 1500]).remove();
+
+reactor.recipeBuilder()
+	.inputs(<gregtech:meta_item_1:2050>)
+	.fluidInputs([<liquid:oxygen> * 4000, <liquid:hydrogen> * 4000])
+	.fluidOutputs(<liquid:phosphoric_acid> * 1000)
+	.duration(320).EUt(16).buildAndRegister();
+
 mods.jei.JEI.removeAndHide(<gregtech:compressed_16:13>);
 mods.jei.JEI.removeAndHide(<appliedenergistics2:facade>.withTag({damage: 13, item: "gregtech:compressed_16"}));
 

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -318,9 +318,22 @@ mixer.findRecipe(8, [<gregtech:meta_item_1:2184> * 3,<gregtech:meta_item_1:2229>
 reactor.findRecipe(384, [<gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000]).remove();
 reactor.recipeBuilder().notConsumable(<gregtech:meta_item_1:32766>.withTag({Configuration: 1})).fluidInputs(<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000).fluidOutputs(<liquid:ammonia> * 4000).EUt(100).duration(320).buildAndRegister();
 
+//Ammonia Recipe: Changes the EU/t and the Output amount
+reactor.findRecipe(384, [<gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000]).remove();
+reactor.recipeBuilder()
+	.notConsumable(<gregtech:meta_item_1:32766>.withTag({Configuration: 1}))
+	.fluidInputs(<liquid:nitrogen> * 1000, <liquid:hydrogen> * 3000)
+	.fluidOutputs(<liquid:ammonia> * 1000)
+	.EUt(100).duration(320).buildAndRegister();
+
+//Dimethylhydrazine: Changes the EU/t
 reactor.findRecipe(480, [null], [<liquid:chloramine> * 1000, <liquid:dimethylamine> * 1000]).remove();
-reactor.findRecipe(480, [null], [<liquid:methanol> * 2000, <liquid:ammonia> * 1000, <liquid:hypochlorous_acid> * 1000]).remove();
-reactor.recipeBuilder().fluidInputs(<liquid:chloramine> * 1000, <liquid:dimethylamine> * 1000).fluidOutputs(<liquid:dimethylhidrazine> * 1000,<liquid:diluted_hydrochloric_acid> * 1000).EUt(120).duration(960).buildAndRegister();
+reactor.recipeBuilder()
+	.fluidInputs(<liquid:chloramine> * 1000, <liquid:dimethylamine> * 1000)
+	.fluidOutputs(<liquid:dimethylhidrazine> * 1000,<liquid:hydrochloric_acid> * 1000).EUt(120).duration(960).buildAndRegister();
+
+//Remove other recipe for Dimethylhydrazine
+reactor.findRecipe(480, [null], [<liquid:methanol> * 2000, <liquid:ammonia> * 2000, <liquid:hypochlorous_acid> * 1000]).remove();
 
 mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:466>);
 mods.jei.JEI.removeAndHide(<gregtech:meta_item_1:1466>);

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -891,7 +891,6 @@ for mat in material {
 	var rotor = allRotor.firstItem;
 
 	//Assembler Recipe
-	assembler.findRecipe(24, [plate * 4, ring], [null]).remove();
 	assembler.recipeBuilder()
 		.inputs(plate*4, ring)
 		.fluidInputs(<liquid:soldering_alloy> * 32)

--- a/overrides/scripts/Midgame.zs
+++ b/overrides/scripts/Midgame.zs
@@ -329,22 +329,6 @@ recipes.addShaped(<enderio:item_material:41>, [
 //Rose Gold Plate
 compressor.recipeBuilder().inputs([<gregtech:meta_item_1:10228>]).outputs([<gregtech:meta_item_1:12228>]).duration(100).EUt(10).buildAndRegister();
 
-
-// Fixes #357: CO2 output should be 4 buckets
-reactor.findRecipe(480,
-    [<gregtech:meta_item_1:2012> * 2, <gregtech:meta_item_1:2122>],
-    [<liquid:chlorine> * 4000])
-    .remove();
-
-reactor.recipeBuilder()
-    .inputs([<gregtech:meta_item_1:2012> * 2, <gregtech:meta_item_1:2122>])
-    .fluidInputs([<liquid:chlorine> * 4000])
-    .fluidOutputs([<liquid:carbon_monoxide> * 4000, <liquid:titanium_tetrachloride> * 1000])
-    .duration(500)
-    .EUt(480)
-    .buildAndRegister();
-// end Fix for #357
-
 //Add back fuel desulfurization recipes removed after the SoG update
 reactor.recipeBuilder()
 	.fluidInputs([<liquid:hydrogen> * 2000, <liquid:sulfuric_naphtha> * 12000])


### PR DESCRIPTION
Updates Gregtech to 1.11.1.632.

This update has a bunch of Chemistry changes (from https://github.com/GregTechCE/GregTech/pull/1414 ) and so is done as a PR.

Notable changes in our scripts: 

- Our modifications to Magnesium Chloride related recipes to make them a closed loop are no longer needed, so those modifications have been removed.
- The removal of an old Rocket Fuel recipe was removed, as it was removed in GTCE
- The removal of rotors in the assembly machine have been removed, as that recipe was removed. However, the addition of the rotor recipe now two changes old (with soldering alloy) remains, as it was already there. Rotors are now made in the Fluid Solidifier.
- The Phosphorus Pentoxide loop was fixed, so our recipe removals there were fixed
- The Ammonia recipe was adjusted to only give 1k mB output in accordance with GTCE's chemistry rules
- The Dimethylhydrazine recipe was adjusted to give Hydrochloric acid instead of the diluted form as a secondary output. This is inline with GTCE's own recipes, just the EU/t requirement has changed.

Notable Changes in GTCE:

- Salt Water was changed, so that it provides no benefit over just using salt
- Some Sulfuric Acid recipes got an additional input or output
- Glyceryl Trinitrate had a recipe removed and now is done through Nitration Mixture
- Uraninite got some additional outputs in its recipe processing
- Silicone Rubber lost a recipe where it was made with Epichlorohydrin
- Tetranitromethane was adjusted to have an additional input and a different output
- Phosphoric Acid had an item output added to a recipe
- Bisphenol A had an output adjusted away from water
- Acetone and Calcium Acetate Solution had some major changes, for which I suggest reading the PR linked above.
- Everything else was just some numerical changes in existing recipes.