### PR TITLE
Add Cutting machine recipes for Thermal blocks -> plates

### DIFF
--- a/overrides/scripts/ThermalExpansion.zs
+++ b/overrides/scripts/ThermalExpansion.zs
@@ -505,3 +505,39 @@ mods.thermalexpansion.Insolator.addRecipe(<appliedenergistics2:material:12>, <ap
 mods.jei.JEI.addDescription(<appliedenergistics2:material:10>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot. Augments do not work for this craft.");
 mods.jei.JEI.addDescription(<appliedenergistics2:material:11>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot. Augments do not work for this craft.");
 mods.jei.JEI.addDescription(<appliedenergistics2:material:12>, "Made in the Crystal Growth Chamber or in a Phytogenic Insolator. If made in the Phytogenic Insolator, make sure to unlock the Fertilizer slot. Augments do not work for this craft.");
+
+
+val liquids as int[][ILiquidStack] = {
+    
+    //Fluid : duration, power
+    <liquid:water> * 150 : [800, 30],
+    <liquid:distilled_water> * 120 : [534, 30],
+    <liquid:lubricant> * 30 : [200, 30]
+
+};
+
+val blocks = [
+
+    //Enderium
+    [<thermalfoundation:storage_alloy:7>, <thermalfoundation:material:359> * 9],
+    //Lumium
+    [<thermalfoundation:storage_alloy:6>, <thermalfoundation:material:358> * 9],
+    //Signalum
+    [<thermalfoundation:storage_alloy:5>, <thermalfoundation:material:357> * 9],
+    //Mana Infused
+    [<thermalfoundation:storage:8>, <thermalfoundation:material:328> * 9]
+
+] as IItemStack[][];
+
+for blockItem in blocks {
+
+    for liquid, values in liquids {
+   
+        saw.recipeBuilder()
+            .inputs(blockItem[0])
+            .fluidInputs(liquid)
+            .outputs(blockItem[1])
+            .duration(values[0]).EUt(values[1]).buildAndRegister();
+
+    }
+}

--- a/overrides/scripts/ThermalExpansion.zs
+++ b/overrides/scripts/ThermalExpansion.zs
@@ -510,9 +510,9 @@ mods.jei.JEI.addDescription(<appliedenergistics2:material:12>, "Made in the Crys
 val liquids as int[][ILiquidStack] = {
     
     //Fluid : duration, power
-    <liquid:water> * 150 : [800, 30],
-    <liquid:distilled_water> * 120 : [534, 30],
-    <liquid:lubricant> * 30 : [200, 30]
+    <liquid:water> * 73 : [1568, 30],
+    <liquid:distilled_water> * 55 : [1019, 30],
+    <liquid:lubricant> * 18 : [392, 30]
 
 };
 


### PR DESCRIPTION
Adds in missing recipes for cutting Thermal Blocks (Mana Infused, Signalum, Lumium, Enderium) into their respective plates.

Closes #559