### PR TITLE
Fix English typos and mistakes

### DIFF
--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -339,7 +339,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§c§rOres in §5Omnifactory§f exist in large clusters, or \u0027§eveins§f\u0027. These veins are scattered around the world, and are relatively common. The §aScanner§f in your inventory can detect any ore within 16 blocks of you, so digging down and scanning should show you any nearby veins. Try scanning now by holding §6right-click§f until the progress meter completes.\n\nWhile the Scanner requires energy to work, you are unlikely to deplete its battery. That said, the quest book will later guide you towards making a §aFlux Capacitor§f to charge tools in your inventory.\n\nIn order to proceed, you\u0027ll need to locate a source of §6Iron§f. You have a few options. §6Magnetite§f veins are higher up and contain large amounts of iron, as well as some §6Vanadium§f and §6Gold§f. Another good source of iron is §6Limonite§f veins, which contain several types of iron. Finally, §6Pyrite§f can be found paired with §6Copper§f in several types of veins.\n\n§6Wrought Iron§f is obtained simply by §esmelting Iron a second time§f. It has more durability than Iron, so it is better for making tools, but §cdo not convert your entire Iron supply over to Wrought Iron§f. The two materials are not interchangable and you\u0027ll need Iron or Wrought Iron as demanded by various recipes.",
+          "desc:8": "§c§rOres in §5Omnifactory§f exist in large clusters, or \u0027§eveins§f\u0027. These veins are scattered around the world, and are relatively common. The §aScanner§f in your inventory can detect any ore within 16 blocks of you, so digging down and scanning should show you any nearby veins. Try scanning now by holding §6right-click§f until the progress meter completes.\n\nWhile the Scanner requires energy to work, you are unlikely to deplete its battery. That said, the quest book will later guide you towards making a §aFlux Capacitor§f to charge tools in your inventory.\n\nIn order to proceed, you\u0027ll need to locate a source of §6Iron§f. You have a few options. §6Magnetite§f veins are higher up and contain large amounts of iron, as well as some §6Vanadium§f and §6Gold§f. Another good source of iron is §6Limonite§f veins, which contain several types of iron. Finally, §6Pyrite§f can be found paired with §6Copper§f in several types of veins.\n\n§6Wrought Iron§f is obtained simply by §esmelting Iron a second time§f. It has more durability than Iron, so it is better for making tools, but §cdo not convert your entire Iron supply over to Wrought Iron§f. The two materials are not interchangeable and you\u0027ll need Iron or Wrought Iron as demanded by various recipes.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -864,7 +864,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "One of the eccentricities of the pack you\u0027ll need to get used to is the way the tools are displayed. Most tools can be made out of nearly any metal, and §bJEI§f will display a huge number of options... every combination of every tool with every material. However, the pattern to make the tool is always identical, so §ejust arrange the plates and ingots in the same manner as the examples, ignoring whatever material it says§f. Rods where rods go, plates where plates, etc. The only restriction is that tools §emust be made from all of the same material§f... you cannot mix and match different metals in a single item.\n\nRecipes will default to showing a \"§6Darmstadtium§f\" tool (or sometimes §6Aluminium§f) of the appropriate type if a tool is required, but the correct type of tool made out of any metal will work. So just ignore the tool\u0027s material in the recipes, it can be whatever you\u0027d like.\n\nFor now, make a §aHammer§f (not a §aMining Hammer§f, mind you... six ingots, not five). Hammers can be used to turn §etwo ingots into one plate§f. §6Plates§f can make a §aFile§f, Files can make §6Rods§f, etc. Use JEI to work your way down the list of tools.\n\n§6Wrought Iron§f is probably your best bet for a tool material right now, but better materials will become available as you progress.",
+          "desc:8": "One of the eccentricities of the pack you\u0027ll need to get used to is the way the tools are displayed. Most tools can be made out of nearly any metal, and §bJEI§f will display a huge number of options... every combination of every tool with every material. However, the pattern to make the tool is always identical, so §ejust arrange the plates and ingots in the same manner as the examples, ignoring whatever material it says§f. Rods where rods go, plates where plates, etc. The only restriction is that tools §emust be made from all of the same material§f... you cannot mix and match different metals in a single item.\n\nRecipes will default to showing a \"§6Darmstadtium§f\" tool (or sometimes §6Aluminium§f) of the appropriate type if a tool is required, but the correct type of tool made out of any metal will work. So, just ignore the tool\u0027s material in the recipes, it can be whatever you\u0027d like.\n\nFor now, make a §aHammer§f (not a §aMining Hammer§f, mind you... six ingots, not five). Hammers can be used to turn §etwo ingots into one plate§f. §6Plates§f can make a §aFile§f, Files can make §6Rods§f, etc. Use JEI to work your way down the list of tools.\n\n§6Wrought Iron§f is probably your best bet for a tool material right now, but better materials will become available as you progress.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -1590,7 +1590,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The main function of this oven is to increase the fuel values of your wood and coal while also recovering some of the various potentially useful waste products.\n\nTurning §6Coal§r into §6Coal Coke§r will not only make it more useful as fuel, but will also produce §9Phenol§r, which you\u0027ll need for circuits.\n\nThe Pyrolyse oven is also the source of several other fluids that can be distilled for useful ingredients.\n\nYou can §6sneak-right click§r the controller to enable the in-world preview.\n",
+          "desc:8": "The main function of this oven is to increase the fuel values of your wood and coal while also recovering some of the various potentially useful waste products.\n\nTurning §6Coal§r into §6Coal Coke§r will not only make it more useful as fuel, but will also produce §9Phenol§r, which you\u0027ll need for circuits.\n\nThe Pyrolyse Oven is also the source of several other fluids that can be distilled for useful ingredients.\n\nYou can §6sneak-right click§r the controller to enable the in-world preview.\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3136,7 +3136,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Being able to fly is nice. This is the first jetpack that uses §bEnderIO§r materials.\n\nThere\u0027s also a quest chain for §bThermal Expansion§r material Jetpacks (starting with the §6Leadstone Jetpack§r). Eventually you\u0027ll need to make both, but not for a long time, so feel free to ignore at least one of these quest chains unless you really really like flying.",
+          "desc:8": "Being able to fly is nice. This is the first jetpack that uses §bEnderIO§r materials.\n\nThere\u0027s also a quest chain for §bThermal Expansion§r material Jetpacks (starting with the §6Leadstone Jetpack§r). Eventually you\u0027ll need to make both, but not for a long time, so feel free to ignore at least one of these quest chains unless you really like flying.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3452,7 +3452,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bEnderIO§f conduits are the preferred way to move fluids around, rather than Gregtech pipes. Incredibly flexible and powerful, they\u0027ll make fluid crafting almost bearable.",
+          "desc:8": "§bEnderIO§f conduits are the preferred way to move fluids around, rather than GregTech pipes. Incredibly flexible and powerful, they\u0027ll make fluid crafting almost bearable.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -3968,7 +3968,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Batteries§r are §bGregTech §rpower storage for §aEU§r energy.\n\nAlthough there are several types of rechargeable batteries you can make, §6Cadmium Batteries§r are the best ones, as they have the most storage capacity. §6Lithium§r is second best, and §6Sodium§r is third.\n\n§6Lithium§r is possible to find inside of §6Tungsten§r veins, however, they are fairly rare. Consider \"buying\" some Lithium with §dOmnicoins§r.\n\n§6Cadmium§r is so tough to get at this point, its not even worth considering. However, §6Sodium§r is plentiful. You can get Sodium by smelting §6Salt§r, with other options becoming available later.",
+          "desc:8": "§6Batteries§r are §bGregTech §rpower storage for §aEU§r energy.\n\nAlthough there are several types of rechargeable batteries you can make, §6Cadmium Batteries§r are the best ones, as they have the most storage capacity. §6Lithium§r is second best, and §6Sodium§r is third.\n\n§6Lithium§r is possible to find inside of §6Tungsten§r veins, however, they are fairly rare. Consider \"buying\" some Lithium with §dOmnicoins§r.\n\n§6Cadmium§r is so tough to get at this point, it's not even worth considering. However, §6Sodium§r is plentiful. You can get Sodium by smelting §6Salt§r, with other options becoming available later.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4349,7 +4349,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aME Chest§r is somewhat impractical to use on its own, but it\u0027s a necessary ingredient for the much more useful §6ME Drive§r.\n\nThis is a rudimentary digital item storage device. By placing a §6Storage Cell§r inside it, you can access the contents as though you were looking through a chest. You can carry the disk to another location and place it down in a different ME Chest if you want, and the items will come with it.\n\n§cDon\u0027t put Storage Cells inside other portable mod inventories like a Satchel, (or vice-versa) as you risk corrupting the contents of the Satchel and the Storage Cell.§r There\u0027s technical reasons why this happens (NBT overflow), and it\u0027s not unique to these items, but that\u0027s not really worth going into.\n\n",
+          "desc:8": "The §aME Chest§r is somewhat impractical to use on its own, but it\u0027s a necessary ingredient for the much more useful §6ME Drive§r.\n\nThis is a rudimentary digital item storage device. By placing a §6Storage Cell§r inside it, you can access the contents as though you were looking through a chest. You can carry the disk to another location and place it down in a different ME Chest if you want, and the items will come with it.\n\n§cDon\u0027t put Storage Cells inside other portable mod inventories like a Satchel, (or vice-versa) as you risk corrupting the contents of the Satchel and the Storage Cell.§r There\u0027re technical reasons why this happens (NBT overflow), and it\u0027s not unique to these items, but that\u0027s not really worth going into.\n\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -4414,7 +4414,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§bApplied Energistics§r uses §6Storage Cells§r as its primary means of digital item and fluid storage.\n\nAll unformatted Storage Cells are limited to at most 63 distinct item types, with the first item of each new type taking up a chunk of the total bytes of cell storage, and subsequent items of existing types taking a small amount of bytes thereafter.\n\nA §61k ME Storage Cell§r is the first and smallest cell for storing items. If you are going to be storing many different kinds of items in your network, you will need to make an §6ME Drive§r and fill it with multiple Storage Cells.\n\nThe §64k ME Storage Cell§r is the next size up. With four times the bytes it holds substantially more items per type, but it requires a more advanced technology than you currently have available: AE §6Processors§r made in an §3Inscriber§r.",
+          "desc:8": "§bApplied Energistics§r uses §6Storage Cells§r as its primary means of digital item and fluid storage.\n\nAll unformatted Storage Cells are limited to at most 63 distinct item types, with the first item of each new type taking up a chunk of the total bytes of cell storage, and subsequent items of existing types taking a small number of bytes thereafter.\n\nA §61k ME Storage Cell§r is the first and smallest cell for storing items. If you are going to be storing many different kinds of items in your network, you will need to make an §6ME Drive§r and fill it with multiple Storage Cells.\n\nThe §64k ME Storage Cell§r is the next size up. With four times the bytes it holds substantially more items per type, but it requires a more advanced technology than you currently have available: AE §6Processors§r made in an §3Inscriber§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5341,7 +5341,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Exquisite Gems§r are mostly needed for crafting special materials.\n\nIf you don\u0027t need them for that though, they can be cut through two cycles in a §3Cutting Machine§r into eight of the basic version of that gem.",
+          "desc:8": "§6Exquisite Gems§r are mostly needed for crafting special materials.\n\nIf you don\u0027t need them for that though, they can be cut through two cycles in a §3Cutting Machine§r into eight of the basic versions of that gem.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -5555,7 +5555,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A hefty amount of §6Silicon Dust§r and a pinch of §6Gallium§r cooked in an §3EBF§r will net you a §6Silicon Boule§r, the starting point for §6Circuit Wafers§r.\n\nMake sure your power system is up to the task. These take a long time to process so you\u0027ll need a signficant amount of energy to safely complete the job.",
+          "desc:8": "A hefty amount of §6Silicon Dust§r and a pinch of §6Gallium§r cooked in an §3EBF§r will net you a §6Silicon Boule§r, the starting point for §6Circuit Wafers§r.\n\nMake sure your power system is up to the task. These take a long time to process so you\u0027ll need a significant amount of energy to safely complete the job.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6074,7 +6074,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You\u0027ll need a variety of §alenses§r for use in §3Precision Laser Engravers§r, all of which are made in the §3Autoclave§r.\n\nInitially you\u0027ll need a §aRed Lens§r, a §aDiamond Lens§r, and a §aGlass Lens§r.\n\nRed Lenses can be made from §6Ruby§r, or alternately with Almandine, Red Garnet, Jasper or Rutile.\n\nThe other two lenses should be self evident.\n\n",
+          "desc:8": "You\u0027ll need a variety of §alenses§r for use in §3Precision Laser Engravers§r, all of which are made in the §3Autoclave§r.\n\nInitially you\u0027ll need a §aRed Lens§r, a §aDiamond Lens§r, and a §aGlass Lens§r.\n\nRed Lenses can be made from §6Ruby§r, or alternately with Almandine, Red Garnet, Jasper or Rutile.\n\nThe other two lenses should be self-evident.\n\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6626,7 +6626,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Form §6Polyethylene Sheets§r using a §3Fluid Solidifer§r and a §aPlate Mold§r for use in crafting electronics components.",
+          "desc:8": "Form §6Polyethylene Sheets§r using a §3Fluid Solidifier§r and a §aPlate Mold§r for use in crafting electronics components.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -6972,7 +6972,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "*Slaps §6ME Drive§r* this bad boy can fit so many §6Storage Cells§r in it!\n\nWith ten slots for Storage Cells, you can store a huge amount of items inside this single block, and search through them all with a §6Terminal§r. You just gotta make all those Storage Cells.\n\nIf you somehow run out of room, you can make another ME Drive for even more slots! So many cells, so many items!",
+          "desc:8": "*Slaps §6ME Drive§r* this bad boy can fit so many §6Storage Cells§r in it!\n\nWith ten slots for Storage Cells, you can store a huge number of items inside this single block, and search through them all with a §6Terminal§r. You just gotta make all those Storage Cells.\n\nIf you somehow run out of room, you can make another ME Drive for even more slots! So, many cells, so many items!",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -7784,7 +7784,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §3Resonator§r is one of the primary crafting machines from §bExtra Utilties 2§r. It requires Grid Power in order to function, and produces special items like §6Stoneburnt§r and §6Red Coal§r.",
+          "desc:8": "The §3Resonator§r is one of the primary crafting machines from §bExtra Utilities 2§r. It requires Grid Power in order to function, and produces special items like §6Stoneburnt§r and §6Red Coal§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -8636,7 +8636,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Surface Mounted Devices§r, or §6SMD§rs for short, are one of the first endgame materials you\u0027ll be making. Even the mighty Tier Nine circuits require SMD components, and huge amounts of them at that.\n\nAll SMD components must be produced in at least an §3MV Assembing Machine§r, and they all will require liquid §9Polyethelyene§r.\n\nStart off with the §6SMD Transistor§r. These are simply a §6Gallium Plate§r and §6Fine Annealed Copper Wire§r.\n\nNext up are §6SMD Resistors§r, which are also simple: §6Carbon Dust§r and §6Fine Electrum Wire§r.\n\nFinally, §6SMD Capacitors§r. You\u0027ll need sheets of §6Polyvinyl Chloride§r to make these, or they can also be made more slowly with §6Silicone Rubber§r.\n\nInvest in an extremely robust system of automation for SMD components and all of their ingredients, since you\u0027ll never stop needing them. They will also work in place of the non-SMD versions you\u0027ve been using in all but the simplest of recipes.\n\n",
+          "desc:8": "§6Surface Mounted Devices§r, or §6SMD§rs for short, are one of the first endgame materials you\u0027ll be making. Even the mighty Tier Nine circuits require SMD components, and huge amounts of them at that.\n\nAll SMD components must be produced in at least an §3MV Assembling Machine§r, and they all will require liquid §9Polyethylene§r.\n\nStart off with the §6SMD Transistor§r. These are simply a §6Gallium Plate§r and §6Fine Annealed Copper Wire§r.\n\nNext up are §6SMD Resistors§r, which are also simple: §6Carbon Dust§r and §6Fine Electrum Wire§r.\n\nFinally, §6SMD Capacitors§r. You\u0027ll need sheets of §6Polyvinyl Chloride§r to make these, or they can also be made more slowly with §6Silicone Rubber§r.\n\nInvest in an extremely robust system of automation for SMD components and all of their ingredients, since you\u0027ll never stop needing them. They will also work in place of the non-SMD versions you\u0027ve been using in all but the simplest of recipes.\n\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9790,7 +9790,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Another common component of any machine that uses fluids. Also usable as a cover for moving fluids between GregTech machines and adjacent tanks or machines.\n\nYou can use Paper Rings or Rubber Rings, but both will require a Knife to craft. A stick and a piece of flint will make a Knife with low durability, or check the recipe for metal ones.",
+          "desc:8": "Another common component of any machine that uses fluids. Also, usable as a cover for moving fluids between GregTech machines and adjacent tanks or machines.\n\nYou can use Paper Rings or Rubber Rings, but both will require a Knife to craft. A stick and a piece of flint will make a Knife with low durability, or check the recipe for metal ones.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -9922,7 +9922,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A perfect material for making chopsticks.\n\nAlso the tier material for Extreme Voltage (EV).",
+          "desc:8": "A perfect material for making chopsticks.\n\nAlso, the tier material for Extreme Voltage (EV).",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -10311,7 +10311,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With tier three circuits in hand, its time to make a §3Distillation Tower§r, which is the gatekeeper for more advanced plastics like §6Epoxy§r and doing petrochemistry.\n\nThe Distillation Tower is a highly flexible multiblock structure, able to be anywhere from §62 blocks high to up to 12 high§r (11 fluid outputs). The way that it works is that each level of the tower after the first will output an additional fluid from the recipe. §cAny output fluids in excess of available buses are voided§r. \n\nWhat you need the Distillation Tower for initially is to break down §9Biomass§r into §9Ethanol§r and §9Water§r. This recipe only has two outputs, so a §ethree-block-high Distillation Tower§r is just fine (the quest materials are for such a tower; if you want to build it bigger, you will need §ean additional 7 casings and 1 fluid output per floor§r).\n\nAny recipe with more than two fluids (like §9Oil§r) will need a larger tower. Make sure to increase the height of your tower to accomodate all of the outputs you want to keep. Also check the voltage requirements of the recipes, as many Distillation Tower recipes need higher voltages than MV. §eYou can swap out your Energy Input for a higher tier one when that time comes§r.\n\nThe tower we\u0027ll be building at first is 3x3x3, with a hollow center. §6Fluid Input Hatch§r §emust go in the very center of the bottom 3x3 layer§r. The §6controller§r goes in the middle of an outer edge of the bottom layer. The §6Output Bus§r and an §6Energy Input Hatch§r can go wherever you can fit them on the bottom layer. The rest of the 3x3 must be filled with §6Clean Stainless Steel Casings§r. Each level above that is a ring of 7 Clean Stainless Steel Casings, one §6Fluid Output§r and nothing in the center, except for the topmost layer which needs an eighth casing to fill in the center, capping off the top.",
+          "desc:8": "With tier three circuits in hand, it\u0027s time to make a §3Distillation Tower§r, which is the gatekeeper for more advanced plastics like §6Epoxy§r and doing petrochemistry.\n\nThe Distillation Tower is a highly flexible multiblock structure, able to be anywhere from §62 blocks high to up to 12 high§r (11 fluid outputs). The way that it works is that each level of the tower after the first will output an additional fluid from the recipe. §cAny output fluids in excess of available buses are voided§r. \n\nWhat you need the Distillation Tower for initially is to break down §9Biomass§r into §9Ethanol§r and §9Water§r. This recipe only has two outputs, so a §ethree-block-high Distillation Tower§r is just fine (the quest materials are for such a tower; if you want to build it bigger, you will need §ean additional 7 casings and 1 fluid output per floor§r).\n\nAny recipe with more than two fluids (like §9Oil§r) will need a larger tower. Make sure to increase the height of your tower to accommodate all of the outputs you want to keep. Also, check the voltage requirements of the recipes, as many Distillation Tower recipes need higher voltages than MV. §eYou can swap out your Energy Input for a higher tier one when that time comes§r.\n\nThe tower we\u0027ll be building at first is 3x3x3, with a hollow center. §6Fluid Input Hatch§r §emust go in the very center of the bottom 3x3 layer§r. The §6controller§r goes in the middle of an outer edge of the bottom layer. The §6Output Bus§r and an §6Energy Input Hatch§r can go wherever you can fit them on the bottom layer. The rest of the 3x3 must be filled with §6Clean Stainless Steel Casings§r. Each level above that is a ring of 7 Clean Stainless Steel Casings, one §6Fluid Output§r and nothing in the center, except for the topmost layer which needs an eighth casing to fill in the center, capping off the top.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -11772,7 +11772,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts LV/MV/HV/EV §3Air Collectors§r.\n\nAn §3Air Colllector§r will suck up air at a decent rate, provided the top side is unobstructed. The collected Air is automatically ejected into an adjacent tank via the output face.\n\nIV and LuV air collectors are not part of this quest, but for reference they exist and are called §3Atmosphere Collectors§r.\n\n",
+          "desc:8": "Note: this quest accepts LV/MV/HV/EV §3Air Collectors§r.\n\nAn §3Air Collector§r will suck up air at a decent rate, provided the top side is unobstructed. The collected Air is automatically ejected into an adjacent tank via the output face.\n\nIV and LuV air collectors are not part of this quest, but for reference they exist and are called §3Atmosphere Collectors§r.\n\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -12682,7 +12682,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With §6Aluminium§r, you can replace the two §aLV Energy Input Hatches§r on your Electric Blast Furnace with a single MV one, if you want. When you\u0027re ready to move on to HV recipes in the EBF, you\u0027ll want to move up to HV Energy Input Hatches, and so on.\n\nHowever, remember to keep the MV area seperate from your LV area. §eHooking up an LV machine to MV current will result in the machine being destroyed! Also LV cables will burn up if you put MV current through them§r. That\u0027s why its probably best to keep the areas separate until you\u0027re comfortable and confident with voltages. Eventually you can use transformers to switch voltages within a single setup, but don\u0027t feel forced to try that until you\u0027ve got a grasp on the basics.\n\nAll RF power is the same (it has no voltages), so you can use RF conduits to route power from wherever you\u0027re generating and storing it to §3CEFs§r for each voltage. You don\u0027t have to use this setup, but its the most foolproof one for a beginner. And if you\u0027re an expert, well... you don\u0027t need my advice.\n\nFor your MV cables, you can use §6Copper§r to start with. §6Energetic Alloy cables§r are lossless though, so consider them if you\u0027re able to mass produce those ingots.",
+          "desc:8": "With §6Aluminium§r, you can replace the two §aLV Energy Input Hatches§r on your Electric Blast Furnace with a single MV one, if you want. When you\u0027re ready to move on to HV recipes in the EBF, you\u0027ll want to move up to HV Energy Input Hatches, and so on.\n\nHowever, remember to keep the MV area separate from your LV area. §eHooking up an LV machine to MV current will result in the machine being destroyed! Also, LV cables will burn up if you put MV current through them§r. That\u0027s why it\u0027s probably best to keep the areas separate until you\u0027re comfortable and confident with voltages. Eventually you can use transformers to switch voltages within a single setup, but don\u0027t feel forced to try that until you\u0027ve got a grasp on the basics.\n\nAll RF power is the same (it has no voltages), so you can use RF conduits to route power from wherever you\u0027re generating and storing it to §3CEFs§r for each voltage. You don\u0027t have to use this setup, but it\u0027s the most foolproof one for a beginner. And if you\u0027re an expert, well... you don\u0027t need my advice.\n\nFor your MV cables, you can use §6Copper§r to start with. §6Energetic Alloy cables§r are lossless though, so consider them if you\u0027re able to mass produce those ingots.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14447,7 +14447,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The Moon is a barren, lifeless rock... So why did you want to come here?\n\nOne major draw is that §6Moon Turf§r, which makes up the surface of the Moon, is an efficient means of obtaining §9Deuterium§r. It will be useful for producing §9Microversium§r, §9Tritium§r, plasmas from fusion, and crystallizing §6Dilithium§r.\n\nThere are also several ores that are rare on the Overworld but exist in abundance on the Moon. In particular, the Moon contains large quantities of §6Titanium§r (in the form of §6Rutile Ore§r and §6Ilmenite Ore§r) and §6Tungsten§r (in the form of §6Scheelite Ore§r and §6Tungstate Ore§r).\n\nMuch later you will also gain access to the §3Lunar Mining Station§r, which as the name suggests only works on the Moon.\n\n",
+          "desc:8": "The Moon is a barren, lifeless rock... So, why did you want to come here?\n\nOne major draw is that §6Moon Turf§r, which makes up the surface of the Moon, is an efficient means of obtaining §9Deuterium§r. It will be useful for producing §9Microversium§r, §9Tritium§r, plasmas from fusion, and crystallizing §6Dilithium§r.\n\nThere are also several ores that are rare on the Overworld but exist in abundance on the Moon. In particular, the Moon contains large quantities of §6Titanium§r (in the form of §6Rutile Ore§r and §6Ilmenite Ore§r) and §6Tungsten§r (in the form of §6Scheelite Ore§r and §6Tungstate Ore§r).\n\nMuch later you will also gain access to the §3Lunar Mining Station§r, which as the name suggests only works on the Moon.\n\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -14585,7 +14585,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is your first §3Microverse Projector§r.\n\nThese structures are used to project §6Micro Miners§r into a §eMicroverse§r to obtain valuable loot such as §6ores§r, §6gems§r, and otherwise unobtainable items§r like §6Radium Salt§r and §6Naquadah Dust§r. §cKeep in mind that Micro Miners are single-use!§r\n\nMicroverse Projectors are §bGregTech§r multiblocks, which means that they\u0027re just as flexible as other machines in terms of the I/O block placement: §epositions of Buses and Hatches can be swapped with any Microverse Projector Casing§r.\n\nA single §6HV Energy Input§r supports missions up to 1024 EU/t. To process the rest you\u0027ll need to upgrade the multiblock to at least §eEV power§r, which is either §6two HV Energy Inputs§r, or §6one EV Energy Input§r. Missions will also overclock, increasing in speed each time the projector\u0027s energy tier increases and available power reaches the next multiple of four times the base mission power.\n\nHover your mouse over the Small Microverse Projector and press §bU§r to see all available missions.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
+          "desc:8": "This is your first §3Microverse Projector§r.\n\nThese structures are used to project §6Micro Miners§r into a §eMicroverse§r to obtain valuable loot such as §6ores§r, §6gems§r, and otherwise unobtainable items§r like §6Radium Salt§r and §6Naquadah Dust§r. §cKeep in mind that Micro Miners are single-use!§r\n\nMicroverse Projectors are §bGregTech§r multiblocks, which means that they\u0027re just as flexible as other machines in terms of the I/O block placement: §epositions of Buses and Hatches can be swapped with any Microverse Projector Casing§r.\n\nA single §6HV Energy Input§r supports missions up to 1024 EU/t. To process the rest, you\u0027ll need to upgrade the multiblock to at least §eEV power§r, which is either §6two HV Energy Inputs§r, or §6one EV Energy Input§r. Missions will also overclock, increasing in speed each time the projector\u0027s energy tier increases and available power reaches the next multiple of four times the base mission power.\n\nHover your mouse over the Small Microverse Projector and press §bU§r to see all available missions.\n\n§6Sneak-right click§r the controller to enable the in-world preview.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15015,7 +15015,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§9Methanol§r and §9Ammonia§r combine together to make §9Dimethylamine§r.\n\nI know you\u0027re expecting a Breaking Bad joke here, but I don\u0027t walt to go for such low hanging fruit.",
+          "desc:8": "§9Methanol§r and §9Ammonia§r combine together to make §9Dimethylamine§r.\n\nI know you\u0027re expecting a Breaking Bad joke here, but I don\u0027t want to go for such low hanging fruit.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -15722,7 +15722,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "With your Rocket built, fuel loaded, and destination set, it\u0027s time for the prelaunch checklist.\n\n- §eMake sure you\u0027re wearing your Space Suit§r (all four pieces) and that it has a full tank of Oxygen. If you plan to stay on the Moon a while, maybe bring a gas charging pad and Ender Tank (being filled with Oxygen) with you.\n\nTeleportation:\n\n- If you decided to go with §aDislocators§r, make sure you take two with you: one bound to the Overworld, the other ready to bind to the Moon. Also bring along a Pedestal to put the Overworld one on the Moon surface.\n\n- If you decided to go with §aTelepads§r, make sure you\u0027ve constructed a Telepad in the Overworld and that you\u0027re carrying coordinates that lead to it. Make sure to bring your Coordinate Selector, blank Paper, and materials for the second Telepad setup. Bring Dew of the Void and RF power (like a §6Solar Panel§r and a §6Capacitor Bank§r).\n\nIn either case, as soon as you land you will need to prepare the other half of the teleportation route, and chunkload it.\n\nWhen you\u0027re sure you\u0027re prepared, sit in your rocket and press §eSpace§r.\n\nLiftoff!",
+          "desc:8": "With your Rocket built, fuel loaded, and destination set, it\u0027s time for the prelaunch checklist.\n\n- §eMake sure you\u0027re wearing your Space Suit§r (all four pieces) and that it has a full tank of Oxygen. If you plan to stay on the Moon a while, maybe bring a gas charging pad and Ender Tank (being filled with Oxygen) with you.\n\nTeleportation:\n\n- If you decided to go with §aDislocators§r, make sure you take two with you: one bound to the Overworld, the other ready to bind to the Moon. Also, bring along a Pedestal to put the Overworld one on the Moon surface.\n\n- If you decided to go with §aTelepads§r, make sure you\u0027ve constructed a Telepad in the Overworld and that you\u0027re carrying coordinates that lead to it. Make sure to bring your Coordinate Selector, blank Paper, and materials for the second Telepad setup. Bring Dew of the Void and RF power (like a §6Solar Panel§r and a §6Capacitor Bank§r).\n\nIn either case, as soon as you land you will need to prepare the other half of the teleportation route, and chunkload it.\n\nWhen you\u0027re sure you\u0027re prepared, sit in your rocket and press §eSpace§r.\n\nLiftoff!",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -16736,7 +16736,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This quest, and the ones that follow it, are §cNOT REQUIRED§r for progression.\n\nOnly do them if you want to be able to explore the various planets offered by Advanced Rocketry and potentially build bases there, or in space.\n\nRefer to the various high quality tutorials on AR available on youtube for specifics.",
+          "desc:8": "This quest, and the ones that follow it, are §cNOT REQUIRED§r for progression.\n\nOnly do them if you want to be able to explore the various planets offered by Advanced Rocketry and potentially build bases there, or in space.\n\nRefer to the various high quality tutorials on AR available on YouTube for specifics.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -21461,7 +21461,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "There are two primary approaches to producing §9Epoxy§r: §9Bisphenol A§r (BPA) and §9Naphtha§r. Both approaches requre §9Epichlorohydrin§r, which itself has a few possible approaches.\n\nNaphtha is the simplest approach, where it is mixed with §9Nitrogen Dioxide§r and Epichlorohydrin to yield Epoxy. This approach is easier but yields less Epoxy. You also forego making more diesel and getting distillation byproducts from Naphtha. If you have an extremely robust §9Oil§r drilling and petrochemistry infrastructure in place, this might be an acceptable choice.\n\nBPA can be produced using petrochemistry distillation products, or via distilling §9Charcoal Byproducts§r from your §3Pyrolyse Oven§r into useful components. Alternatively, you can get §9Phenol§r from §6Coal§r pyrolysis. §9Fermented Biomass§r is also useful to distill as it provides many useful products. Epoxy made from BPA is more complex to set up initially, but also far more efficient.\n\nThe final decision is down to you make. Check out recipes in §bJEI§r.",
+          "desc:8": "There are two primary approaches to producing §9Epoxy§r: §9Bisphenol A§r (BPA) and §9Naphtha§r. Both approaches require §9Epichlorohydrin§r, which itself has a few possible approaches.\n\nNaphtha is the simplest approach, where it is mixed with §9Nitrogen Dioxide§r and Epichlorohydrin to yield Epoxy. This approach is easier but yields less Epoxy. You also forego making more diesel and getting distillation byproducts from Naphtha. If you have an extremely robust §9Oil§r drilling and petrochemistry infrastructure in place, this might be an acceptable choice.\n\nBPA can be produced using petrochemistry distillation products, or via distilling §9Charcoal Byproducts§r from your §3Pyrolyse Oven§r into useful components. Alternatively, you can get §9Phenol§r from §6Coal§r pyrolysis. §9Fermented Biomass§r is also useful to distill as it provides many useful products. Epoxy made from BPA is more complex to set up initially, but also far more efficient.\n\nThe final decision is down to you make. Check out recipes in §bJEI§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -23421,7 +23421,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The full complexity of §bNuclearCraft§r is far too much for the scope of this quest guide, so §eyou\u0027re encouraged to watch a tutorial or read a guide online§r. For the purposes of this particular quest, you\u0027ll be building a cheap breeder reactor to make §6Plutonium§r. This is a very basic reactor and can be changed to run faster and safer.\n\nFirst, set up your 54 §6Reactor Casings§r to encase a 3x3 cube shape of empty air. The Casings should only cover the faces of the interior cube, not the edges or corners. You should have exactly the right number of Casings to encase a 3x3 space.\n\nNext, create a hole so you can get inside the cube. Place the §6Reactor Cells§r in all 8 corners. Then the §6Lapis Coolers§r will go between them: 4 on the top layer and 4 on the bottom layer. At this point, the top and botom layers should have eight blocks each with an empty middle, and the middle layer is fully empty. In the middle layer, place the 4 §6Graphite Blocks§r on the corners, and the 4 §6Glowstone Coolers§r on the sides (so they touch both Lapis Coolers). Now the cube should be full, except for an empty column in the middle. The reactor will now be complete when you reseal it up with the Casings you removed to access the interior.\n\nFinally, place the §3Fission Reactor Controller§r along any edge or corner of the reactor. Opening the Reactor Controller GUI should let you know that the structure was properly formed; if not, go back and check what you did wrong.\n\nThe lever is placed on the reactor, as a redstone signal is required for it to start working. §cReactors can overheat and melt if the temperature exceeds its ability to cool.§r You can make a safety loop on the controller (instead of the lever) to automatically shut off the reactor when it starts getting hot using a §aRedstone Conduit§r, a §aRedstone Sensor Filter§r (on the input channel), and a §aRedstone NOT Filter§r (on the output channel). Make sure input and output are on the same channel color.",
+          "desc:8": "The full complexity of §bNuclearCraft§r is far too much for the scope of this quest guide, so §eyou\u0027re encouraged to watch a tutorial or read a guide online§r. For the purposes of this particular quest, you\u0027ll be building a cheap breeder reactor to make §6Plutonium§r. This is a very basic reactor and can be changed to run faster and safer.\n\nFirst, set up your 54 §6Reactor Casings§r to encase a 3x3 cube shape of empty air. The Casings should only cover the faces of the interior cube, not the edges or corners. You should have exactly the right number of Casings to encase a 3x3 space.\n\nNext, create a hole so you can get inside the cube. Place the §6Reactor Cells§r in all 8 corners. Then the §6Lapis Coolers§r will go between them: 4 on the top layer and 4 on the bottom layer. At this point, the top and bottom layers should have eight blocks each with an empty middle, and the middle layer is fully empty. In the middle layer, place the 4 §6Graphite Blocks§r on the corners, and the 4 §6Glowstone Coolers§r on the sides (so they touch both Lapis Coolers). Now the cube should be full, except for an empty column in the middle. The reactor will now be complete when you reseal it up with the Casings you removed to access the interior.\n\nFinally, place the §3Fission Reactor Controller§r along any edge or corner of the reactor. Opening the Reactor Controller GUI should let you know that the structure was properly formed; if not, go back and check what you did wrong.\n\nThe lever is placed on the reactor, as a redstone signal is required for it to start working. §cReactors can overheat and melt if the temperature exceeds its ability to cool.§r You can make a safety loop on the controller (instead of the lever) to automatically shut off the reactor when it starts getting hot using a §aRedstone Conduit§r, a §aRedstone Sensor Filter§r (on the input channel), and a §aRedstone NOT Filter§r (on the output channel). Make sure input and output are on the same channel color.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -24412,7 +24412,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§oNow this is not the end. It is not even the beginning of the end. But it is, perhaps, the end of the beginning.§r\n\nThe §d§dCreative Portable Tank§r is a major milestone. Great work!\n\nThis tank is your first proper creative item, which can be set to a fluid and then provides an infinite quantity of that fluid. The first fluid you should do this with is §dMolten Creative Portable Tank§r, so you can make as many more tanks as you want! You get exactly enough from a §6Heart of a Universe§r to do this.\n\nFrom there you can set up tanks with infinite quantities of every fluid you can think of.  §3Fluid Solidifiers§r can be used to make infinite of every element you can melt and solidify.\n\nThis is quite a game-changer as far as infrastructure goes. You\u0027ll find that many machines won\u0027t need to be used for their original purpose anymore. Some major base redesign is in order. Have you considered moving to space?\n\nAll that said, §ethe pack will still be challenging to complete§r. Infinite resources and power is nice, but it\u0027s not everything. There are plenty of materials you can\u0027t melt, and creative items will push your factory automation engineering skills to their limits.\n\nOnward to the final challenge: the §dCreative Vending Upgrade§r!\n\n",
+          "desc:8": "§oNow this is not the end. It is not even the beginning of the end. But it is, perhaps, the end of the beginning.§r\n\nThe §d§dCreative Portable Tank§r is a major milestone. Great work!\n\nThis tank is your first proper creative item, which can be set to a fluid and then provides an infinite quantity of that fluid. The first fluid you should do this with is §dMolten Creative Portable Tank§r, so you can make as many more tanks as you want! You get exactly enough from a §6Heart of a Universe§r to do this.\n\nFrom there you can set up tanks with infinite quantities of every fluid you can think of.  §3Fluid Solidifiers§r can be used to make infinite of every element you can melt and solidify.\n\nThis is quite a game-changer as far as infrastructure goes. You\u0027ll find that many machines won\u0027t need to be used for their original purpose anymore. Some major base redesign is in order. Have you considered moving to space?\n\nAll that said, §ethe pack will still be challenging to complete§r. Infinite resources and power are nice, but it\u0027s not everything. There are plenty of materials you can\u0027t melt, and creative items will push your factory automation engineering skills to their limits.\n\nOnward to the final challenge: the §dCreative Vending Upgrade§r!\n\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -24474,7 +24474,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A §aGrappling Hook§f is very useful in an urban enviroment.\n\nThere are lots of ways to upgrade and improve your Grappling Hook, so play around with it.\n\nOpen your inventory and look for the Baubles button, click it to reveal the additional bauble slots and put the Hook there.\n\nThe default key is §6C§r, however since quite a lot of mods occupy this hotkey you\u0027ll need to visit the controls menu to resolve the button conflicts.",
+          "desc:8": "A §aGrappling Hook§f is very useful in an urban environment.\n\nThere are lots of ways to upgrade and improve your Grappling Hook, so play around with it.\n\nOpen your inventory and look for the Baubles button, click it to reveal the additional bauble slots and put the Hook there.\n\nThe default key is §6C§r, however since quite a lot of mods occupy this hotkey you\u0027ll need to visit the controls menu to resolve the button conflicts.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -25812,7 +25812,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Basic §aFlux Capacitors§r hold a whopping lot of energy - §a10 million RF§r - and are useful for keeping your §aRF-powered§r equipment and tools charged.\n\nPut one into your newly crafted §3CEF§r to charge it. You can then put it in your inventory to charge your items with §aRF§r, or you can leave it in the CEF to act as a §a2.5 million EU§r battery!\n\nFlux Capacitor is a §bBauble§r, open your inventory and look for the Baubles button, click it to reveal the additional bauble slots menu and put it into any slot you wish.\n\nFinally you can charge up all those depleted §6Dark Boots§r and §6The Ender§r swords you\u0027ve looted.",
+          "desc:8": "Basic §aFlux Capacitors§r hold a whopping lot of energy - §a10 million RF§r - and are useful for keeping your §aRF-powered§r equipment and tools charged.\n\nPut one into your newly crafted §3CEF§r to charge it. You can then put it in your inventory to charge your items with §aRF§r, or you can leave it in the CEF to act as a §a2.5 million EU§r battery!\n\nFlux Capacitor is a §bBauble§r, open your inventory and look for the Baubles button, click it to reveal the additional bauble slots menu and put it into any slot you wish.\n\nFinally, you can charge up all those depleted §6Dark Boots§r and §6The Ender§r swords you\u0027ve looted.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26109,7 +26109,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§3Large Plasma Turbines§r are a powerful late game method of generating power. One Large Plasma Turbine can produce nearly 41800 EU/t when using an §aLuV Rotor Holder§r and equipped with §a100% efficiency§r rotor.\n\nOne §3Mark 1 Fusion Reactor§r dedicated to producing §bOxygen Plasma§r can provide suffient fuel for continuously operating 16 Large Plasma Turbines, resulting in a combined production of roughly 670000 EU/t. Granted, this is a decent amount of infrastructure.\n\nDon\u0027t rely on §bJEI§r too much when looking for the best plasma: fuels are displayed in a very misleading manner. A Large Plasma Turbine consumes up to nearly 16 buckets of plasma to run a cycle for the duration specified in JEI, and takes some time to spin up to full power.",
+          "desc:8": "§3Large Plasma Turbines§r are a powerful late game method of generating power. One Large Plasma Turbine can produce nearly 41800 EU/t when using an §aLuV Rotor Holder§r and equipped with §a100% efficiency§r rotor.\n\nOne §3Mark 1 Fusion Reactor§r dedicated to producing §bOxygen Plasma§r can provide sufficient fuel for continuously operating 16 Large Plasma Turbines, resulting in a combined production of roughly 670000 EU/t. Granted, this is a decent amount of infrastructure.\n\nDon\u0027t rely on §bJEI§r too much when looking for the best plasma: fuels are displayed in a very misleading manner. A Large Plasma Turbine consumes up to nearly 16 buckets of plasma to run a cycle for the duration specified in JEI, and takes some time to spin up to full power.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26339,7 +26339,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "GregTech adds a very versatile way of augmenting machines with §aMachine Covers§r. Covers are \"upgrades\" that you can put on any GregTech machine, chest, or drum to expand its functionality. To work with covers, you\u0027ll need to make yourself a §aScrewdriver§r to configure covers, and a §aCrowbar§r to remove covers without having to break the machine.\n\nHere\u0027s a quick list of what covers there are in the game, and what they do:\n\n- §a§lFilter§r: controls what items can enter or leave through a particular side, with 9 configurable slots and whitelist/blacklist modes. You can also put a filter into a §aConveyor§r or §aRobotic Arm§r to customize what items they will move. There\u0027s also a §9Fluid§r variant of the filter, which offers the same controls and can be placed in §aPumps§f.\n\n- §a§lOre Dictionary Filter§r: a specialized filter that uses ore dictionary entries and supports \"*\" as a wildcard, e. g. \"§6ingotHot*§r\" will match all hot ingots, and \"§6dustTiny*§r\" will match all tiny piles.\n\n- §a§lConveyor§r: transfers items to or from an adjacent inventory.\n\n- §a§lRobotic Arm§r: is much like §aConveyor§r, but has two additional modes: §6Keep Exact§r, which keeps the exact amount of items in the inventory, and §6Supply Exact§r which transfers the exact amount of items per operation (useful for packaging tiny piles when used with §aOre Dictionary Filter§f!). This cover is very useful for crafting automation.\n\n- §a§lPump§r: is much like a §aConveyor§f, but for fluids.\n\n- §a§lShutter§r: prevents any interactions with a side.\n\n- §a§lMachine Controller§r: enables or disables a machine and/or its covers depending on whether it is receiving a redstone signal. Useful when paired with §6ME level emitters§f to keep resources in stock.",
+          "desc:8": "GregTech adds a very versatile way of augmenting machines with §aMachine Covers§r. Covers are \"upgrades\" that you can put on any GregTech machine, chest, or drum to expand its functionality. To work with covers, you\u0027ll need to make yourself a §aScrewdriver§r to configure covers, and a §aCrowbar§r to remove covers without having to break the machine.\n\nHere\u0027s a quick list of what covers there are in the game, and what they do:\n\n- §a§lFilter§r: controls what items can enter or leave through a particular side, with 9 configurable slots and whitelist/blacklist modes. You can also put a filter into a §aConveyor§r or §aRobotic Arm§r to customize what items they will move. There\u0027s also a §9Fluid§r variant of the filter, which offers the same controls and can be placed in §aPumps§f.\n\n- §a§lOre Dictionary Filter§r: a specialized filter that uses ore dictionary entries and supports \"*\" as a wildcard, e. g. \"§6ingotHot*§r\" will match all hot ingots, and \"§6dustTiny*§r\" will match all tiny piles.\n\n- §a§lConveyor§r: transfers items to or from an adjacent inventory.\n\n- §a§lRobotic Arm§r: is much like §aConveyor§r, but has two additional modes: §6Keep Exact§r, which keeps the exact number of items in the inventory, and §6Supply Exact§r which transfers the exact number of items per operation (useful for packaging tiny piles when used with §aOre Dictionary Filter§f!). This cover is very useful for crafting automation.\n\n- §a§lPump§r: is much like a §aConveyor§f, but for fluids.\n\n- §a§lShutter§r: prevents any interactions with a side.\n\n- §a§lMachine Controller§r: enables or disables a machine and/or its covers depending on whether it is receiving a redstone signal. Useful when paired with §6ME level emitters§f to keep resources in stock.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -26450,7 +26450,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "You can easily automate most §bGregTech§r machines with §aME Interfaces§r and processing §aPatterns§r early on by using the machines\u0027s auto-output feature.\n\nUse a §aGregTech Wrench§r to relocate the output side of a machine where you want it to be, right-click it with a §aGregTech Screwdriver§r to permit input on the output face, then put an ME Interface on that side of the machine.\n\nRight-click the machine and enable item auto-output (§6orange box§r in the bottom-left corner of the GUI).\n\nNow, stuff the ME Interface with processing patterns. The next time you order an item, the ME Interface will push ingredients into the machine, and the machine will push outputs back into the Interface once they\u0027re ready, completing the craft. No need to use conduits or import buses!",
+          "desc:8": "You can easily automate most §bGregTech§r machines with §aME Interfaces§r and processing §aPatterns§r early on by using the machines\u0027 auto-output feature.\n\nUse a §aGregTech Wrench§r to relocate the output side of a machine where you want it to be, right-click it with a §aGregTech Screwdriver§r to permit input on the output face, then put an ME Interface on that side of the machine.\n\nRight-click the machine and enable item auto-output (§6orange box§r in the bottom-left corner of the GUI).\n\nNow, stuff the ME Interface with processing patterns. The next time you order an item, the ME Interface will push ingredients into the machine, and the machine will push outputs back into the Interface once they\u0027re ready, completing the craft. No need to use conduits or import buses!",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30643,7 +30643,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Great for automatically converting between Nuggets, Ingots, and Blocks of metals, or simply storing massive amounts of things. Also works with §dOmnicoins§r.\n\nThe appearance can be customized by crafting the drawer into §aFramed Compacting Drawer§r and putting it into a §aFraming Table§r.",
+          "desc:8": "Great for automatically converting between Nuggets, Ingots, and Blocks of metals, or simply storing massive amounts of things. Also, works with §dOmnicoins§r.\n\nThe appearance can be customized by crafting the drawer into §aFramed Compacting Drawer§r and putting it into a §aFraming Table§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30781,7 +30781,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Now that you have a §3Wiremill§r, you can turn one §6Copper Wire§r into four §6Fine Copper Wire§r. The recipes for §6Resistors§r, §6LV Motors§r and §6Vacuum Tubes§r all accept either type, so doing this extra processing step will make your §6Copper Ingots§r go §efour times further§r when making circuits.\n\nYou\u0027ll be making a lot more circuits from here on out, so its definitely worthwhile to save your copper!",
+          "desc:8": "Now that you have a §3Wiremill§r, you can turn one §6Copper Wire§r into four §6Fine Copper Wire§r. The recipes for §6Resistors§r, §6LV Motors§r and §6Vacuum Tubes§r all accept either type, so doing this extra processing step will make your §6Copper Ingots§r go §efour times further§r when making circuits.\n\nYou\u0027ll be making a lot more circuits from here on out, so it\u0027s definitely worthwhile to save your copper!",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -30937,7 +30937,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A small appetizer, before the §dOmnium§r main couse.\n\nAs the name suggests, this catalyst is formed from exotic non-elemental materials and alloys.",
+          "desc:8": "A small appetizer, before the §dOmnium§r main course.\n\nAs the name suggests, this catalyst is formed from exotic non-elemental materials and alloys.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31120,7 +31120,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts both LV and MV Brewery.\n\nYou can turn §6Plant Balls§r and other various §6sugary crops§r into §9Biomass§r with a §3Brewery§r. Biomass is the first step towards making Plastic in the form of §9Polyethylene§r.\n\nThe Brewery is a very very slow machine, but it requires almost no power. Building higher tier Breweries, or many LV ones, is necessary to brew enough Biomass for plastics.",
+          "desc:8": "Note: this quest accepts both LV and MV Brewery.\n\nYou can turn §6Plant Balls§r and other various §6sugary crops§r into §9Biomass§r with a §3Brewery§r. Biomass is the first step towards making Plastic in the form of §9Polyethylene§r.\n\nThe Brewery is a very slow machine, but it requires almost no power. Building higher tier Breweries, or many LV ones, is necessary to brew enough Biomass for plastics.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -31853,7 +31853,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Not as common a component, but used in a number of critical machines.\n\nAlso useful as a machine cover for continuously moving items.",
+          "desc:8": "Not as common a component, but used in a number of critical machines.\n\nAlso, useful as a machine cover for continuously moving items.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -33884,7 +33884,7 @@
           "ismain:1": 1,
           "issilent:1": 0,
           "lockedprogress:1": 1,
-          "name:8": "I Dont Need No Stinkin\u0027 Tower",
+          "name:8": "I Don\u0027t Need No Stinkin\u0027 Tower",
           "partysinglereward:1": 0,
           "questlogic:8": "AND",
           "repeat_relative:1": 1,
@@ -34346,7 +34346,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Being able to fly is pretty sick. Its also pretty expensive.\n\nIts probably a bit premature to consider a §6jetpack§r at this point, but if you really want to craft this bad boy, I won\u0027t stop you.\n\nThere\u0027s also a quest chain for §bEnderIO§r Jetpacks (starting with the §6Conductive Iron Jetpack§r). Eventually you\u0027ll need to make both, but not for a long time, so feel free to ignore at least one of these quest chains unless you really really like flying.",
+          "desc:8": "Being able to fly is pretty sick. It\u0027s also pretty expensive.\n\nIt\u0027s probably a bit premature to consider a §6jetpack§r at this point, but if you really want to craft this bad boy, I won\u0027t stop you.\n\nThere\u0027s also a quest chain for §bEnderIO§r Jetpacks (starting with the §6Conductive Iron Jetpack§r). Eventually you\u0027ll need to make both, but not for a long time, so feel free to ignore at least one of these quest chains unless you really like flying.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34721,7 +34721,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This is an augment that will work in all §3dynamos§f. It increases the efficiency of the fuel being used inside the dynamo, increasing the power it generates. However, the rate of power generation remains the same, the fuel simply lasts longer. So while §6Fuel Catalyzers§f decrease the amount you\u0027ll need to go mining for §6Coal§f, they won\u0027t boost your production of RF per second.\n\nEach Fuel Catalyzer increases fuel efficiency by §a15%§f, additively (so two will make fuel last §a30% longer§f, three is §a45% longer§f, etc).",
+          "desc:8": "This is an augment that will work in all §3dynamos§f. It increases the efficiency of the fuel being used inside the dynamo, increasing the power it generates. However, the rate of power generation remains the same, the fuel simply lasts longer. So, while §6Fuel Catalyzers§f decrease the amount you\u0027ll need to go mining for §6Coal§f, they won\u0027t boost your production of RF per second.\n\nEach Fuel Catalyzer increases fuel efficiency by §a15%§f, additively (so two will make fuel last §a30% longer§f, three is §a45% longer§f, etc.).",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -34786,7 +34786,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "The §aAuxiliary Transmission Coil §ris an augment that will work in all types of dynamos. It will consume fuel faster to produce a correspondingly higher RF per tick.\n\nEach augment increases both base power production and fuel consumption by 100%, additively (so the second is 200%, third is 300%, etc).\n\nConsider the tradeoffs however, as you could just make another dynamo, and you miss out on §aFuel Catalyzer§r augments that make fuels burn longer for more total RF generated. The Auxiliary Transmission Coil will put additional stress your fuel production infrastructure.\n\nIf that\u0027s an acceptable tradeoff, then Auxiliary Transmission Coils are a cheap and effective way to boost your power production.",
+          "desc:8": "The §aAuxiliary Transmission Coil §ris an augment that will work in all types of dynamos. It will consume fuel faster to produce a correspondingly higher RF per tick.\n\nEach augment increases both base power production and fuel consumption by 100%, additively (so the second is 200%, third is 300%, etc.).\n\nConsider the tradeoffs however, as you could just make another dynamo, and you miss out on §aFuel Catalyzer§r augments that make fuels burn longer for more total RF generated. The Auxiliary Transmission Coil will put additional stress your fuel production infrastructure.\n\nIf that\u0027s an acceptable tradeoff, then Auxiliary Transmission Coils are a cheap and effective way to boost your power production.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 2,
@@ -41408,7 +41408,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Take a peek at The §eEnd Game quest book tab§f. This might seem a bit premature to suggest, but it has a reason.\n\nThese are quests for a full stack of many of the materials in the game. Those are the materials you\u0027ll need to synthesize §5Omnium§r, the basic end game resource. Its the pack\u0027s way of letting you know what materials you should be prepared to mass produce as you approach the end.\n\nOf course, its not necessary or even advisable to try to finish up all of these quests the moment they become available. Some will be incredibly easy (like §6Iron§f and §6Copper§f), others will be brutally grindy at early tech levels. The rewards are all the same: §d25 Omnicoins each§f, so use your best judgement on which ones to complete and which to ignore for later.",
+          "desc:8": "Take a peek at The §eEnd Game quest book tab§f. This might seem a bit premature to suggest, but it has a reason.\n\nThese are quests for a full stack of many of the materials in the game. Those are the materials you\u0027ll need to synthesize §5Omnium§r, the basic end game resource. It\u0027s the pack\u0027s way of letting you know what materials you should be prepared to mass produce as you approach the end.\n\nOf course, it\u0027s not necessary or even advisable to try to finish up all of these quests the moment they become available. Some will be incredibly easy (like §6Iron§f and §6Copper§f), others will be brutally grindy at early tech levels. The rewards are all the same: §d25 Omnicoins each§f, so use your best judgement on which ones to complete and which to ignore for later.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -41847,7 +41847,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Low-Enriched Curium 243, or §6LECm-243§r, is made from §6Curium-243§r and §6Curium-246§r.\n\n§6Depleted LECm-243 Fuel§r gives mostly Curium-246 back, but also small quantities of §6Berkelium§r and §6Californium§r isotopes.\n\n§6HECm-247§r is a better alternative for strictly Califronium, if your reactor can withstand the heat.",
+          "desc:8": "Low-Enriched Curium 243, or §6LECm-243§r, is made from §6Curium-243§r and §6Curium-246§r.\n\n§6Depleted LECm-243 Fuel§r gives mostly Curium-246 back, but also small quantities of §6Berkelium§r and §6Californium§r isotopes.\n\n§6HECm-247§r is a better alternative for strictly Californium, if your reactor can withstand the heat.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44525,7 +44525,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "When you first started the pack, we told you that ore doubling can wait, and that\u0027s true... But you will need to start doing some rudimentary ore processing for §ebyproducts§r.\n\nByproducts are additional materials that can only be obtained from processing ores in certain machines. For example, there is no \"Gallium Ore\". You get §6Gallium§r as a byproduct from processing other ores.\n\nOres have various means of processing, and eventually you\u0027ll use machine pipelines to process ores in specific ways to optimize what byproducts you gain. You can walk through JEI to figure out the path you want for each ore (always look for machine sources of small and tiny piles too).\n\nThe relevant machines are as follows:\n \n- §3Macerator§r: turns ores into §6Crushed Ores§r, Crushed Ores into §6Impure Dusts§r, and §6Purified Crushed Ores§r into §6Pure Dusts§r. Higher tiers of macerators have byproduct slots and gain a chance to get a full pile of byproduct from ores and both types of crushed ores.\n\n- §3Washer§r: cleans Crushed Ores with §9Water§r, making Purified Crushed Ores§r, and a guaranteed 3 tiny piles of byproduct. Using §9Distilled Water§r makes them go faster. This is an improved alternative to dropping dusts in a Cauldron.\n\n- §3Chemical Bath§r: similar to a washer, but uses chemicals to purify the crushed ores. Has a chance to give a full pile of byproducts, often different than what the Washer would give.\n\n- §3§3Centrifuge§r: separates Pure or Impure dusts into the final material, producing a guaranteed 3 tiny piles of byproduct.\n\n- §3Electrolyzer§r: uses power to split compounds into individual elements, sometimes gaining useful byproducts in the proces.\n\nThe §3Thermal Centrifuge§r, not to be confused with the regular Centrifuge, can be used for alternative ore processing but is §edreadfully slow and power-hungry§r. No LV form exists, and its primary use is for §bNuclearCraft§r fission fuels.\n\nYour first forays into ore processing for byproducts will be the Electrolyzer and the Centrifuge.\n",
+          "desc:8": "When you first started the pack, we told you that ore doubling can wait, and that\u0027s true... But you will need to start doing some rudimentary ore processing for §ebyproducts§r.\n\nByproducts are additional materials that can only be obtained from processing ores in certain machines. For example, there is no \"Gallium Ore\". You get §6Gallium§r as a byproduct from processing other ores.\n\nOres have various means of processing, and eventually you\u0027ll use machine pipelines to process ores in specific ways to optimize what byproducts you gain. You can walk through JEI to figure out the path you want for each ore (always look for machine sources of small and tiny piles too).\n\nThe relevant machines are as follows:\n \n- §3Macerator§r: turns ores into §6Crushed Ores§r, Crushed Ores into §6Impure Dusts§r, and §6Purified Crushed Ores§r into §6Pure Dusts§r. Higher tiers of macerators have byproduct slots and gain a chance to get a full pile of byproduct from ores and both types of crushed ores.\n\n- §3Washer§r: cleans Crushed Ores with §9Water§r, making Purified Crushed Ores§r, and a guaranteed 3 tiny piles of byproduct. Using §9Distilled Water§r makes them go faster. This is an improved alternative to dropping dusts in a Cauldron.\n\n- §3Chemical Bath§r: similar to a washer, but uses chemicals to purify the crushed ores. Has a chance to give a full pile of byproducts, often different than what the Washer would give.\n\n- §3§3Centrifuge§r: separates Pure or Impure dusts into the final material, producing a guaranteed 3 tiny piles of byproduct.\n\n- §3Electrolyzer§r: uses power to split compounds into individual elements, sometimes gaining useful byproducts in the process.\n\nThe §3Thermal Centrifuge§r, not to be confused with the regular Centrifuge, can be used for alternative ore processing but is §edreadfully slow and power-hungry§r. No LV form exists, and its primary use is for §bNuclearCraft§r fission fuels.\n\nYour first forays into ore processing for byproducts will be the Electrolyzer and the Centrifuge.\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -44733,7 +44733,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Your §3Chemical Reactors§r will be making a lot of different fluids. You\u0027ll need to manage the logistics of routing and storing all the different fluids you\u0027re automating.\n\nWherever possible, having one Chemical Reactor output directly into another machine that needs its output chemical saves you from having to figure out additional storage and routing. §aFluid Filters§r and §aPump covers§r are very useful for moving fluids around a compact processing pipeline.\n\nBut what about the final output fluids that you need elsewhere?\n\nOne option is to use the output tanks of the Chemical Reactors as a small storage buffer, letting it back up and stop crafting automatically. A §aFluid Storage Bus§r on the machine will expose the fluid to your ME Network. Whenever you need some of this fluid, your AE2 system will pull the needed fluid out and the machine will resume processing.\n\nThere\u0027s some catches with this approach though. First is that the inaccessible input tanks will also show up in AE but you won\u0027t be able to access them. You will want to set the Storage Bus to §eExport Only§r so AE doesn\u0027t try to store random fluids in the Chemical Reactor, and you may want to §ereduce the priority§r of the Storage Bus as well: this will signal to AE that you want it to remove fluids from that location first. Also, if multiple fluids are produced, §ethe machine will not resume processing if it doesn\u0027t have room for all fluid outputs§r.\n\nWhen you get access to them, it\u0027s probably just better to use single-fluid-formatted §aFluid Storage Cells§r and dump outputs into AE via Fluid Interfaces. You can fill up the cells, then pull the fluids out wherever else you need them.\n\n",
+          "desc:8": "Your §3Chemical Reactors§r will be making a lot of different fluids. You\u0027ll need to manage the logistics of routing and storing all the different fluids you\u0027re automating.\n\nWherever possible, having one Chemical Reactor output directly into another machine that needs its output chemical saves you from having to figure out additional storage and routing. §aFluid Filters§r and §aPump covers§r are very useful for moving fluids around a compact processing pipeline.\n\nBut what about the final output fluids that you need elsewhere?\n\nOne option is to use the output tanks of the Chemical Reactors as a small storage buffer, letting it back up and stop crafting automatically. A §aFluid Storage Bus§r on the machine will expose the fluid to your ME Network. Whenever you need some of this fluid, your AE2 system will pull the needed fluid out and the machine will resume processing.\n\nThere\u0027re some catches with this approach though. First is that the inaccessible input tanks will also show up in AE but you won\u0027t be able to access them. You will want to set the Storage Bus to §eExport Only§r so AE doesn\u0027t try to store random fluids in the Chemical Reactor, and you may want to §ereduce the priority§r of the Storage Bus as well: this will signal to AE that you want it to remove fluids from that location first. Also, if multiple fluids are produced, §ethe machine will not resume processing if it doesn\u0027t have room for all fluid outputs§r.\n\nWhen you get access to them, it\u0027s probably just better to use single-fluid-formatted §aFluid Storage Cells§r and dump outputs into AE via Fluid Interfaces. You can fill up the cells, then pull the fluids out wherever else you need them.\n\n",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45408,7 +45408,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "A very power-efficient, if slow before upgrades, means of creating plates. Also the only way to directly make plates from single gems.\n\nUpgrading the machine tier with §aUpgrade Kits§r and applying §aAugments§r to boost its crafting speed is a good idea.\n\nPlates and Platings that are gated specifically by later §bGregTech§r voltage tiers are not craftable in these (instead requiring a §3Compressor§r), but almost every single-ingredient recipe made in a Compressor is available.",
+          "desc:8": "A very power-efficient, if slow before upgrades, means of creating plates. Also, the only way to directly make plates from single gems.\n\nUpgrading the machine tier with §aUpgrade Kits§r and applying §aAugments§r to boost its crafting speed is a good idea.\n\nPlates and Platings that are gated specifically by later §bGregTech§r voltage tiers are not craftable in these (instead requiring a §3Compressor§r), but almost every single-ingredient recipe made in a Compressor is available.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -45632,7 +45632,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Upgrade time! \n...or building a new one, which is probably better.\n\nYet again this quest asks for the minimal amount of casings. Make an extra 28 if you don\u0027t want more than §a2 Fluid Inputs§r§r and §a1 Fluid Output§r.\n\nIf you insist on upgrading instead of making a new one, don\u0027t dismantle the current one before you\u0027re sure you\u0027ve got everything you need to upgrade it, or you might end up having to rebuild the §3Mark 1 Fusion Reactor§r again.",
+          "desc:8": "Upgrade time! \n...or building a new one, which is probably better.\n\nYet again this quest asks for the minimal number of casings. Make an extra 28 if you don\u0027t want more than §a2 Fluid Inputs§r§r and §a1 Fluid Output§r.\n\nIf you insist on upgrading instead of making a new one, don\u0027t dismantle the current one before you\u0027re sure you\u0027ve got everything you need to upgrade it, or you might end up having to rebuild the §3Mark 1 Fusion Reactor§r again.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -46103,7 +46103,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "This pack has §bBuilding Gadgets§r.\n\nThese devices can help you build, swap blocks, destroy massive areas, or even copy-paste regions. You need the blocks you plan to paste in your inventory though; it doesn\u0027t make them from nothing.\n\nAlso important to note that it won\u0027t work with TileEntities, so it pretty much only works with simple blocks (not stuff like machines).\n\nBy default, the config GUI is bound to §6G§r.",
+          "desc:8": "This pack has §bBuilding Gadgets§r.\n\nThese devices can help you build, swap blocks, destroy massive areas, or even copy-paste regions. You need the blocks you plan to paste in your inventory though; it doesn\u0027t make them from nothing.\n\nAlso, important to note that it won\u0027t work with TileEntities, so it pretty much only works with simple blocks (not stuff like machines).\n\nBy default, the config GUI is bound to §6G§r.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,
@@ -47607,7 +47607,7 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Gregtech Low Voltage Tier: start building a factory!\n\nGenerate resources with §bDeep Mob Learning§r.\n\nBuild an §3Electric Blast Furnace§r for smelting advanced materials and alloys.\n\nEarly §bEnderIO§r tech and §bApplied Energistics 2§r Digital Storage.",
+          "desc:8": "GregTech Low Voltage Tier: start building a factory!\n\nGenerate resources with §bDeep Mob Learning§r.\n\nBuild an §3Electric Blast Furnace§r for smelting advanced materials and alloys.\n\nEarly §bEnderIO§r tech and §bApplied Energistics 2§r Digital Storage.",
           "icon:10": {
             "Count:3": 0,
             "Damage:2": 0,
@@ -48160,7 +48160,7 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Gregtech Medium Voltage Tier: new machines and rudimentary ore processing.\n\nOrganic Chemistry for §6Plastics§r, and build a §3Distillation Tower§r.\n\n§bApplied Energistics 2§r automation. Explore §bActually Additions§r.",
+          "desc:8": "GregTech Medium Voltage Tier: new machines and rudimentary ore processing.\n\nOrganic Chemistry for §6Plastics§r, and build a §3Distillation Tower§r.\n\n§bApplied Energistics 2§r automation. Explore §bActually Additions§r.",
           "icon:10": {
             "Count:3": 0,
             "Damage:2": 0,
@@ -48895,7 +48895,7 @@
         "betterquesting:10": {
           "bg_image:8": "",
           "bg_size:3": 256,
-          "desc:8": "Gregtech High Voltage, Extreme Voltage, and Insane Voltage tiers:\n\n§6§3Cryogenic Distillation§r, and petrochemistry for §6Epoxy§r and §9Cetane Diesel§r.\n\nCraft §6Nether Stars§r and unlock §bThermal Expansion§r machines.\n\nBuild a§b NuclearCraft§r fission reactor to obtain new materials.\n\nBuild a Space Station and Warp Core.",
+          "desc:8": "GregTech High Voltage, Extreme Voltage, and Insane Voltage tiers:\n\n§6§3Cryogenic Distillation§r, and petrochemistry for §6Epoxy§r and §9Cetane Diesel§r.\n\nCraft §6Nether Stars§r and unlock §bThermal Expansion§r machines.\n\nBuild a§b NuclearCraft§r fission reactor to obtain new materials.\n\nBuild a Space Station and Warp Core.",
           "icon:10": {
             "Count:3": 0,
             "Damage:2": 0,

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -5341,7 +5341,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "§6Exquisite Gems§r are mostly needed for crafting special materials.\n\nIf you don\u0027t need them for that though, they can be cut through two cycles in a §3Cutting Machine§r into eight of the basic versions of that gem.",
+          "desc:8": "§6Exquisite Gems§r are mostly needed for crafting special materials.\n\nIf you don\u0027t need them for that though, they can be cut through two cycles in a §3Cutting Machine§r into eight of the basic version of that gem.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,


### PR DESCRIPTION
Fix some English typos and mistakes in `DefaultQuests.json` using Microsoft Word.

Consider some of long lines are marked as different but do not have extra selection for which part of line is different. For example it's quite hard to understand that the first line is `interchangable` -> `interchangeable`, but you can find out this by alignment of words with respect to each other (at least find the line which is different).