### PR TITLE
Remove Duplicate Conductive Iron Cable Recipes

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -796,16 +796,6 @@ recipes.addShaped(<gregtech:machine:273>, [
 	[<gregtech:meta_item_1:32643>, <gregtech:machine:504>, <gregtech:fluid_pipe:2072>],
 	[<ore:wireGtQuadrupleNichrome>, <ore:wireGtQuadrupleNichrome>, <ore:circuitExtreme>]]);
 
-//conductive iron cables by hand
-recipes.addShapeless(<gregtech:cable:6700>, [<gregtech:cable:5700>,<gregtech:cable:5700>]);
-recipes.addShapeless(<gregtech:cable:7700>, [<gregtech:cable:6700>,<gregtech:cable:6700>]);
-recipes.addShapeless(<gregtech:cable:8700>, [<gregtech:cable:7700>,<gregtech:cable:7700>]);
-recipes.addShapeless(<gregtech:cable:9700>, [<gregtech:cable:8700>,<gregtech:cable:8700>]);
-
-recipes.addShapeless(<gregtech:cable:8700> * 2, [<gregtech:cable:9700>]);
-recipes.addShapeless(<gregtech:cable:7700> * 2, [<gregtech:cable:8700>]);
-recipes.addShapeless(<gregtech:cable:6700> * 2, [<gregtech:cable:7700>]);
-recipes.addShapeless(<gregtech:cable:5700> * 2, [<gregtech:cable:6700>]);
 
 
 recipes.addShapeless(<gregtech:meta_item_1:2700>, [<gregtech:meta_item_1:2033>,<minecraft:redstone>]);


### PR DESCRIPTION
While playing the pack on dev snapshot `3d4192e`, I noticed that there were some duplicate cable crafting recipes for Conductive Iron cables due to recipes changes in GTCE, changed by https://github.com/GregTechCE/GregTech/pull/1405. This PR simply removes those duplicate recipes.

An example of a recipe being duplicated:
![Capture](https://user-images.githubusercontent.com/10861407/110739036-fdcd6880-81f5-11eb-901e-bbd3e285d859.PNG)

You can see in this picture that the 2 2x cables -> 4x cable recipe is duplicated.

I checked all other cables, and saw no other duplicate recipes like this.