### PR TITLE
Switch some item renames to lang renames

### DIFF
--- a/overrides/resources/modpack/lang/en_us.lang
+++ b/overrides/resources/modpack/lang/en_us.lang
@@ -1,0 +1,14 @@
+metaitem.circuit.energy_flow.name=Crystal Processor
+metaitem.circuit.quantum_processor.name=§5Quantum Circuit
+metaitem.circuit.nano_processor_assembly.name=Nanoprocessor
+metaitem.circuit.nano_processor.name=Nanocircuit
+metaitem.circuit.processor_assembly.name=Microprocessor
+metaitem.circuit.basic_electronic.name=Electronic Circuit
+metaitem.circuit.basic.name=Primitive Circuit
+metaitem.quantumeye.name=Quantum Eye
+metaitem.board.phenolic.name=Phenolic Substrate
+metaitem.circuit.wetware_processor.name=Wetware Circuit
+metaitem.circuit.wetware_assembly.name=Wetware Processor
+metaitem.circuit.wetware_super_computer.name=Wetware Processor Array
+metaitem.circuit.wetware_mainframe.name=Wetware Processor Mainframe
+metaitem.quantumstar.name=§5Quantum Star

--- a/overrides/resources/modpack/lang/ru_ru.lang
+++ b/overrides/resources/modpack/lang/ru_ru.lang
@@ -1,0 +1,14 @@
+metaitem.circuit.energy_flow.name=Crystal Processor
+metaitem.circuit.quantum_processor.name=§5Quantum Circuit
+metaitem.circuit.nano_processor_assembly.name=Nanoprocessor
+metaitem.circuit.nano_processor.name=Nanocircuit
+metaitem.circuit.processor_assembly.name=Microprocessor
+metaitem.circuit.basic_electronic.name=Electronic Circuit
+metaitem.circuit.basic.name=Primitive Circuit
+metaitem.quantumeye.name=Quantum Eye
+metaitem.board.phenolic.name=Phenolic Substrate
+metaitem.circuit.wetware_processor.name=Wetware Circuit
+metaitem.circuit.wetware_assembly.name=Wetware Processor
+metaitem.circuit.wetware_super_computer.name=Wetware Processor Array
+metaitem.circuit.wetware_mainframe.name=Wetware Processor Mainframe
+metaitem.quantumstar.name=§5Quantum Star

--- a/overrides/resources/modpack/lang/zh_cn.lang
+++ b/overrides/resources/modpack/lang/zh_cn.lang
@@ -1,0 +1,14 @@
+metaitem.circuit.energy_flow.name=Crystal Processor
+metaitem.circuit.quantum_processor.name=§5Quantum Circuit
+metaitem.circuit.nano_processor_assembly.name=Nanoprocessor
+metaitem.circuit.nano_processor.name=Nanocircuit
+metaitem.circuit.processor_assembly.name=Microprocessor
+metaitem.circuit.basic_electronic.name=Electronic Circuit
+metaitem.circuit.basic.name=Primitive Circuit
+metaitem.quantumeye.name=Quantum Eye
+metaitem.board.phenolic.name=Phenolic Substrate
+metaitem.circuit.wetware_processor.name=Wetware Circuit
+metaitem.circuit.wetware_assembly.name=Wetware Processor
+metaitem.circuit.wetware_super_computer.name=Wetware Processor Array
+metaitem.circuit.wetware_mainframe.name=Wetware Processor Mainframe
+metaitem.quantumstar.name=§5Quantum Star

--- a/overrides/scripts/Electronics.zs
+++ b/overrides/scripts/Electronics.zs
@@ -20,9 +20,7 @@ recipes.addShaped(<metaitem:circuit.basic>, [
 	[<metaitem:circuit.vacuum_tube>, <metaitem:board.coated>, <metaitem:circuit.vacuum_tube>], 
 	[<ore:cableGtSingleRedAlloy>,<ore:cableGtSingleRedAlloy>,<ore:cableGtSingleRedAlloy>]]);
 
-<gregtech:meta_item_2:32487>.displayName = "Primitive Circuit";
-<gregtech:meta_item_2:32487>.clearTooltip();
-<gregtech:meta_item_2:32487>.addTooltip("Primitive Circuit");
+
 <gregtech:meta_item_2:32487>.addTooltip(format.aqua(format.italic("This is the first Tier One circuit.")));
 	
 	
@@ -45,10 +43,6 @@ recipes.addShaped(<metaitem:component.glass.tube>, [
 	
 	
 //Electronic Circuit
-
-<metaitem:circuit.basic_electronic>.displayName = "Electronic Circuit";
-<metaitem:circuit.basic_electronic>.clearTooltip();
-<metaitem:circuit.basic_electronic>.addTooltip("Electronic Circuit");
 <metaitem:circuit.basic_electronic>.addTooltip(format.aqua(format.italic("This is the second Tier One circuit.")));
 
 assembler.findRecipe(8, [<metaitem:plate.integrated_logic_circuit>, <metaitem:component.resistor> * 2, <metaitem:component.capacitor>, <metaitem:board.phenolic>, <ore:wireFineCopper>.firstItem], [<liquid:tin> * 144]).remove();
@@ -152,10 +146,6 @@ recipes.addShaped(<contenttweaker:combinationcircuit>, [
 	[<ore:plateWroughtIron>, <metaitem:circuit.basic>, <ore:cableGtSingleRedAlloy>], 
 	[<metaitem:circuit.basic>, <metaitem:component.diode>, <metaitem:circuit.basic>], 
 	[<ore:cableGtSingleRedAlloy>, <metaitem:circuit.basic>, <ore:plateWroughtIron>]]);
-
-<metaitem:board.phenolic>.displayName = "Phenolic Substrate";
-<metaitem:board.phenolic>.clearTooltip();
-<metaitem:board.phenolic>.addTooltip("Phenolic Substrate");	
 	
 	
 	
@@ -240,10 +230,6 @@ assembler.recipeBuilder().inputs([<metaitem:component.smd.resistor> * 2, <metait
 
 
 //Microprocessor
-
-<metaitem:circuit.processor_assembly>.displayName = "Microprocessor";
-<metaitem:circuit.processor_assembly>.clearTooltip();
-<metaitem:circuit.processor_assembly>.addTooltip("Microprocessor");
 <metaitem:circuit.processor_assembly>.addTooltip(format.aqua(format.italic("This is the third Tier Three circuit.")));
 
 assembler.findRecipe(90, [<metaitem:circuit.advanced> * 2, <metaitem:component.capacitor> * 4, <metaitem:component.small_coil> * 4, <metaitem:board.plastic>, <metaitem:plate.random_access_memory> * 4, <ore:wireFineRedAlloy>.firstItem * 12], [<liquid:tin> * 288]).remove();
@@ -259,10 +245,6 @@ assembler.recipeBuilder().inputs([<contenttweaker:microcircuit> * 3, <metaitem:p
 
 
 //Nanocircuit
-
-<metaitem:circuit.nano_processor>.displayName = "Nanocircuit";
-<metaitem:circuit.nano_processor>.clearTooltip();
-<metaitem:circuit.nano_processor>.addTooltip("Nanocircuit");
 <metaitem:circuit.nano_processor>.addTooltip(format.aqua(format.italic("This is the fourth and final Tier Three circuit.")));
 
 assembler.findRecipe(480, [<metaitem:component.smd.resistor> * 2, <metaitem:component.smd.capacitor> * 4, <metaitem:component.smd.transistor> * 2, <metaitem:board.epoxy>, <metaitem:plate.nano_central_processing_unit>, <ore:wireFineElectrum>.firstItem * 2], [<liquid:tin> * 144]).remove();
@@ -302,10 +284,6 @@ assembler.recipeBuilder().inputs([<metaitem:component.smd.diode> * 4, <metaitem:
 
 
 //Nanoprocessor
-
-<metaitem:circuit.nano_processor_assembly>.displayName = "Nanoprocessor";
-<metaitem:circuit.nano_processor_assembly>.clearTooltip();
-<metaitem:circuit.nano_processor_assembly>.addTooltip("Nanoprocessor");
 <metaitem:circuit.nano_processor_assembly>.addTooltip(format.aqua(format.italic("This is the third Tier Four circuit.")));
 
 assembler.findRecipe(480, [<metaitem:component.smd.capacitor> * 4, <metaitem:component.small_coil> * 4, <metaitem:circuit.nano_processor> * 2, <metaitem:board.epoxy>, <metaitem:plate.random_access_memory> * 4, <ore:wireFineElectrum>.firstItem * 6], [<liquid:tin> * 288]).remove();
@@ -317,10 +295,6 @@ assembler.recipeBuilder().inputs([<metaitem:circuit.nano_processor> * 3, <metait
 
 
 //Quantum Circuit
-
-<metaitem:circuit.quantum_processor>.displayName = "Quantum Circuit";
-<metaitem:circuit.quantum_processor>.clearTooltip();
-<metaitem:circuit.quantum_processor>.addTooltip("Quantum Circuit");
 <metaitem:circuit.quantum_processor>.addTooltip(format.aqua(format.italic("This is the fourth and final Tier Four circuit.")));
 
 assembler.findRecipe(1960, [<metaitem:component.smd.capacitor> * 4, <metaitem:component.smd.transistor> * 2, <metaitem:board.fiber_reinforced>, <metaitem:plate.nano_central_processing_unit>, <metaitem:plate.qbit_central_processing_unit>, <ore:wireFinePlatinum>.firstItem * 2], [<liquid:tin> * 144]).remove();
@@ -405,10 +379,6 @@ assembler.recipeBuilder().inputs([<metaitem:component.smd.diode> * 8, <metaitem:
 
 
 //Crystal Processor
-
-<metaitem:circuit.energy_flow>.displayName = "Crystal Processor";
-<metaitem:circuit.energy_flow>.clearTooltip();
-<metaitem:circuit.energy_flow>.addTooltip("Crystal Processor");
 <metaitem:circuit.energy_flow>.addTooltip(format.aqua(format.italic("This is the third Tier Six circuit.")));
 
 assembler.findRecipe(7600, [<metaitem:component.smd.capacitor> * 4, <metaitem:component.small_coil> * 4, <metaitem:board.multilayer.fiber_reinforced>, <metaitem:plate.random_access_memory> * 4, <metaitem:circuit.crystal_processor> * 2, <ore:wireFineNiobiumTitanium>.firstItem * 6], [<liquid:tin> * 288]).remove();
@@ -420,10 +390,6 @@ assembler.recipeBuilder().inputs([<metaitem:component.smd.capacitor> * 4, <conte
 
 
 //Wetware Circuit
-
-<metaitem:circuit.wetware_processor>.displayName = "Wetware Circuit";
-<metaitem:circuit.wetware_processor>.clearTooltip();
-<metaitem:circuit.wetware_processor>.addTooltip("Wetware Circuit");
 <metaitem:circuit.wetware_processor>.addTooltip(format.aqua(format.italic("This is the fourth and final Tier Six circuit.")));
 
 assembler.recipeBuilder().inputs([<gregtech:meta_item_2:32476> * 4, <gregtech:cable:308> * 4, <gregtech:meta_item_2:32449>]).fluidInputs(<liquid:sterilized_growth_medium> * 1000).outputs([<metaitem:circuit.wetware_processor> * 4]).duration(200).EUt(120000).buildAndRegister();
@@ -450,10 +416,6 @@ assembly_line.recipeBuilder().inputs([<metaitem:component.smd.diode> * 8, <metai
 
 
 //Wetware Processor
-
-<metaitem:circuit.wetware_assembly>.displayName = "Wetware Processor";
-<metaitem:circuit.wetware_assembly>.clearTooltip();
-<metaitem:circuit.wetware_assembly>.addTooltip("Wetware Processor");
 <metaitem:circuit.wetware_assembly>.addTooltip(format.aqua(format.italic("This is the third and final Tier Seven circuit.")));
 
 assembly_line.recipeBuilder().inputs(<gregtech:meta_item_2:32459> * 16, <gregtech:meta_item_1:19391> * 16, <gregtech:meta_item_2:32460> * 16, <gregtech:meta_item_2:32458> * 8, <gregtech:meta_item_2:32457> * 8, <gregtech:meta_item_2:32498> * 2, <gregtech:meta_item_2:32449>, <enderio:item_material:42> * 2, <gregtech:meta_item_2:32485> * 4, <gregtech:cable:710> * 6).fluidInputs(<liquid:sterilized_growth_medium> * 2000).outputs(<gregtech:meta_item_2:32499>).duration(400).EUt(120000).buildAndRegister();
@@ -470,10 +432,6 @@ assembly_line.recipeBuilder().inputs([<metaitem:component.smd.resistor> * 48, <g
  
  
 //Wetware Processor Array 
- 
-<metaitem:circuit.wetware_super_computer>.displayName = "Wetware Processor Array";
-<metaitem:circuit.wetware_super_computer>.clearTooltip();
-<metaitem:circuit.wetware_super_computer>.addTooltip("Wetware Processor Array");
 <metaitem:circuit.wetware_super_computer>.addTooltip(format.aqua(format.italic("This is the second and final Tier Eight circuit.")));
 
 assembly_line.recipeBuilder().inputs(<gregtech:meta_item_2:32459> * 32, <gregtech:meta_item_1:19391> * 32, <gregtech:meta_item_2:32460> * 32, <gregtech:meta_item_2:32458> * 16, <gregtech:meta_item_2:32457> * 16, <gregtech:meta_item_1:12022> * 4, <gregtech:cable:354> * 8, <gregtech:meta_item_2:32499> * 2, <enderio:item_material:44> * 8).fluidInputs(<liquid:soldering_alloy> * 1152).outputs(<gregtech:meta_item_2:32500>).duration(600).EUt(122880).buildAndRegister();
@@ -483,9 +441,7 @@ assembly_line.recipeBuilder().inputs(<gregtech:meta_item_2:32459> * 32, <gregtec
 /////////////////   Tier Nine Circuits | Infinite Tier   ///////////////////////
 
 
-<metaitem:circuit.wetware_mainframe>.displayName = "Wetware Processor Mainframe";
-<metaitem:circuit.wetware_mainframe>.clearTooltip();
-<metaitem:circuit.wetware_mainframe>.addTooltip("Wetware Processor Mainframe");
+
 <metaitem:circuit.wetware_mainframe>.addTooltip(format.aqua(format.italic("This is the first and only Tier Nine circuit.")));
 
 

--- a/overrides/scripts/ExtendedCrafting.zs
+++ b/overrides/scripts/ExtendedCrafting.zs
@@ -1053,9 +1053,6 @@ makeExtremeRecipe9(<contenttweaker:eternalcatalyst>,
       K : <moreplates:empowered_restonia_gear>,
       L : <moreplates:empowered_void_gear> });
 <contenttweaker:eternalcatalyst>.addTooltip(format.darkGray(format.italic("Gaze into the Abyss...")));
-<gregtech:meta_item_1:32725>.clearTooltip();
-<gregtech:meta_item_1:32725>.addTooltip(format.darkPurple("Quantum Star"));
-<gregtech:meta_item_1:32725>.displayName = "Quantum Star";
 
 
 ////////////////////////// Infinity Ingot ///////////////////////

--- a/overrides/scripts/JEICleanup.zs
+++ b/overrides/scripts/JEICleanup.zs
@@ -64,3 +64,13 @@ recipes.removeShaped(<gregtech:meta_tool:32>, [
 recipes.removeShaped(<gregtech:meta_tool:32>, [
                     [<ore:gtceWrenches>, <*>, <ore:gtceScrewdrivers>],
                     [null, <gregtech:meta_item_2:32576>, null]]);
+
+
+<gregtech:meta_item_2:32494>.removeTooltip("Quantum computing comes to life!");
+<gregtech:meta_item_2:32447>.removeTooltip("A Good Board");
+<gregtech:meta_item_2:32492>.removeTooltip("Smaller than ever");
+<gregtech:meta_item_2:32487>.removeTooltip("A Basic Circuit");
+//<gregtech:meta_item_1:32724>.removeTooltip("Quantum Eye");
+<gregtech:meta_item_2:32498>.removeTooltip("You have a feeling like it's watching you");
+<gregtech:meta_item_2:32499>.removeTooltip("Can run Minecraft");
+//<gregtech:meta_item_1:32725>.removeTooltip("Quantum Star");

--- a/overrides/scripts/Microverse.zs
+++ b/overrides/scripts/Microverse.zs
@@ -248,11 +248,6 @@ makeExtremeRecipe7(<contenttweaker:tiersixship>,
 	  T : <simplyjetpacks:metaitemmods:29> }
 );
 
-<gregtech:meta_item_1:32724>.displayName = "Quantum Eye";
-<gregtech:meta_item_1:32724>.clearTooltip();
-<gregtech:meta_item_1:32724>.addTooltip(format.darkPurple("Quantum Eye"));
-
-
 /////////////	 Tier Seven Space Ship  	  //////////////////
 
 makeExtremeRecipe9(<contenttweaker:tiersevenship>,


### PR DESCRIPTION
This PR switches some items, namely gtce items, from using `.displayName` to set their display names to instead use a lang file.

When using the `.displayName` method, items were still showing the old name in some circumstances, like in the quest book or in AE2 crafts. This should no longer be an issue after switching to lang overrides.

In addition, since the tooltips are now no longer cleared for the items, it is possible to see the advanced information, when previously it was not possible to see the advanced information. There were some items that had a tooltip added by a mod, so those were removed using the `removeTooltip` method, except for when the tooltip matched the item name, as the remove method takes a regrex input.