### PR TITLE
Update GTCE and SoG

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -422,7 +422,7 @@
     },
     {
       "projectID": 293327,
-      "fileID": 3233106,
+      "fileID": 3249033,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -482,7 +482,7 @@
     },
     {
       "projectID": 316751,
-      "fileID": 3233808,
+      "fileID": 3250256,
       "required": true
     },
     {

--- a/overrides/scripts/BlastFurnace.zs
+++ b/overrides/scripts/BlastFurnace.zs
@@ -141,7 +141,11 @@ blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:2078>]).outputs([<gr
 //Tungstencarbide [tier 5]
 blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2300>], [null]).remove();	
 blast_furnace.findRecipe(480, [<gregtech:meta_item_1:10074>,<gregtech:meta_item_1:2012>], [null]).remove();
-blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:10074>,<gregtech:meta_item_1:2012>]).outputs([<gregtech:meta_item_1:11300>]).property("temperature", 2700).duration(500).EUt(480).buildAndRegister();	
+blast_furnace.recipeBuilder()
+	.inputs([<gregtech:meta_item_1:10074>,<gregtech:meta_item_1:2012>])
+	.outputs([<gregtech:meta_item_1:11300> * 2])
+	.property("temperature", 2700)
+	.duration(500).EUt(480).buildAndRegister();	
 furnace.addRecipe(<gregtech:meta_item_1:10300>, <gregtech:meta_item_1:2300>, 0.0);
 
 //Tungstensteel [tier 5]

--- a/overrides/scripts/BlastFurnace.zs
+++ b/overrides/scripts/BlastFurnace.zs
@@ -53,9 +53,17 @@ blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2231>], [null]).remove();
 blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:2231>]).outputs([<gregtech:meta_item_1:10231>]).property("temperature", 1000).duration(200).EUt(120).buildAndRegister();
 
 //Annealed Copper [tier 1]
-blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2018>], [<liquid:oxygen> * 1000]).remove();	
-blast_furnace.findRecipe(120, [<gregtech:meta_item_1:10018>], [<liquid:oxygen> * 1000]).remove();	
-blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:10018>]).fluidInputs([<liquid:oxygen> * 1000]).outputs([<gregtech:meta_item_1:10087>]).property("temperature", 1000).duration(200).EUt(120).buildAndRegister();
+//Remove Annealed Copper recipes from Copper dust and ingot
+blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2018>, <gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:oxygen> * 1000]).remove();
+blast_furnace.findRecipe(120, [<gregtech:meta_item_1:10018>, <gregtech:meta_item_1:32766>.withTag({Configuration: 1})], [<liquid:oxygen> * 1000]).remove();
+//Adjusting the Temperature and duration of Annealed Copper
+blast_furnace.recipeBuilder()
+	.inputs([<gregtech:meta_item_1:10018>])
+	.fluidInputs([<liquid:oxygen> * 1000])
+	.circuit(1)
+	.outputs([<gregtech:meta_item_1:10087>])
+	.property("temperature", 1000)
+	.duration(200).EUt(120).buildAndRegister();
 
 //HSLA - unused
 //blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:10184>]).fluidInputs([<liquid:oxygen> * 1000]).outputs([<nuclearcraft:alloy:15>]).property("temperature", 1000).duration(200).EUt(120).buildAndRegister();

--- a/overrides/scripts/BlastFurnace.zs
+++ b/overrides/scripts/BlastFurnace.zs
@@ -99,10 +99,10 @@ blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2232>], [null]).remove();
 blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:2232>]).outputs([<gregtech:meta_item_1:10232>]).property("temperature", 1700).duration(600).EUt(120).buildAndRegister();
 
 //Nickel Zinc Ferrite [tier 3]
+//Furnace Recipe from NZF dust
 furnace.addRecipe(<gregtech:meta_item_1:10424>, <gregtech:meta_item_1:2424>, 0.0);
-blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2423>], [<liquid:oxygen> * 2000]).remove();	
-blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2424>], [null]).remove();	
-blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:2423>]).fluidInputs([<liquid:oxygen> * 2000]).outputs([<gregtech:meta_item_1:10424>]).property("temperature", 1700).duration(600).EUt(120).buildAndRegister();
+//Remove the recipe from NZF dust
+blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2424>], [null]).remove();
 
 //Stainless Steel [tier 3]
 blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2183>], [null]).remove();	

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -1100,3 +1100,6 @@ makeShaped("gtce_rotor_mold", <metaitem:shape.mold.rotor>,
 recipes.removeByRecipeName("gregtech:scanner_battery.re.lv.lithium");
 recipes.removeByRecipeName("gregtech:scanner_battery.re.lv.cadmium");
 recipes.removeByRecipeName("gregtech:scanner_battery.re.lv.sodium");
+
+//Temporary removal of a duplicate recipe
+reactor.findRecipe(30, [<metaitem:dustSodiumBisulfate> * 7], [<liquid:water> * 1000]).remove();

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -1110,3 +1110,5 @@ reactor.recipeBuilder()
 	.fluidOutputs(<liquid:tetranitromethane> * 1000, <liquid:water> * 4000)
 	.outputs(<metaitem:dustCarbon> * 3)
 	.duration(480).EUt(120).buildAndRegister();
+
+electrolyzer.findRecipe(60, [null], [<liquid:glycerol> * 1000]).remove();

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -1103,3 +1103,10 @@ recipes.removeByRecipeName("gregtech:scanner_battery.re.lv.sodium");
 
 //Temporary removal of a duplicate recipe
 reactor.findRecipe(30, [<metaitem:dustSodiumBisulfate> * 7], [<liquid:water> * 1000]).remove();
+
+//Tetranitromethane recipe as a holdover
+reactor.recipeBuilder()
+	.fluidInputs(<liquid:ethenone> * 2000, <liquid:nitric_acid> * 4000)
+	.fluidOutputs(<liquid:tetranitromethane> * 1000, <liquid:water> * 4000)
+	.outputs(<metaitem:dustCarbon> * 3)
+	.duration(480).EUt(120).buildAndRegister();

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -332,15 +332,6 @@ reactor.recipeBuilder()
 //Remove other recipe for Dimethylhydrazine
 reactor.findRecipe(480, [null], [<liquid:methanol> * 2000, <liquid:ammonia> * 2000, <liquid:hypochlorous_acid> * 1000]).remove();
 
-//Phosphoric Acid, fix mol amounts
-reactor.findRecipe(30, [<gregtech:meta_item_1:2050>], [<liquid:oxygen> * 2500, <liquid:water> * 1500]).remove();
-
-reactor.recipeBuilder()
-	.inputs(<gregtech:meta_item_1:2050> * 2)
-	.fluidInputs([<liquid:oxygen> * 5000, <liquid:water> * 3000])
-	.fluidOutputs(<liquid:phosphoric_acid> * 2000)
-	.duration(320).EUt(16).buildAndRegister();
-
 mods.jei.JEI.removeAndHide(<gregtech:compressed_16:13>);
 mods.jei.JEI.removeAndHide(<appliedenergistics2:facade>.withTag({damage: 13, item: "gregtech:compressed_16"}));
 

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -944,13 +944,6 @@ electrolyzer.recipeBuilder()
 	.fluidOutputs(<liquid:oxygen> * 2000, <liquid:hydrogen> * 6000)
 	.duration(288).EUt(60).buildAndRegister();
 
-//Methyl Acetate
-electrolyzer.recipeBuilder()
-	.fluidInputs(<liquid:methyl_acetate> * 11000)
-	.outputs(<ore:dustCarbon>.firstItem * 3)
-	.fluidOutputs(<liquid:oxygen> * 2000, <liquid:hydrogen> * 6000)
-	.duration(264).EUt(60).buildAndRegister();
-
 //Dichlorobenzene
 electrolyzer.recipeBuilder()
 	.fluidInputs(<liquid:dichlorobenzene> * 12000)

--- a/overrides/scripts/Endgame.zs
+++ b/overrides/scripts/Endgame.zs
@@ -452,5 +452,3 @@ reactor.recipeBuilder()
   .duration(600).EUt(1920).buildAndRegister();
 
 reactor.findRecipe(1920, [<gregtech:meta_item_2:32467>, <gregtech:cable:5354> * 8], [null]).remove();
-
-fusion_reactor.findRecipe(32768, [null], [<liquid:lithium> * 16, <liquid:tungsten> * 16]).remove();

--- a/overrides/scripts/zzzFixStuff.zs
+++ b/overrides/scripts/zzzFixStuff.zs
@@ -2,6 +2,7 @@ import mods.gregtech.recipe.RecipeMap;
 import mods.gregtech.material.MaterialRegistry;
 import mods.contenttweaker.VanillaFactory;
 import mods.contenttweaker.Color;
+import crafttweaker.item.IItemStack;
 
 print("--- Exa is fixing stuff! ---");
 
@@ -110,4 +111,25 @@ recipes.addShaped("of_craft_airtight_seal",
     [[<contenttweaker:omnicoin100>, <contenttweaker:omnicoin100>, <contenttweaker:omnicoin100>],
      [<contenttweaker:omnicoin100>, <contenttweaker:omnicoin100>, <contenttweaker:omnicoin100>],
      [<contenttweaker:omnicoin100>, <contenttweaker:omnicoin100>, <contenttweaker:omnicoin100>]]);
+
+//Temporary recipe for red alloy with annealed copper in EBF, and adjusting the times of red alloy
+//Red Alloy with annealed copper
+val coppers = [<metaitem:ingotAnnealedCopper>, <metaitem:dustAnnealedCopper>, <metaitem:ingotCopper>, <metaitem:dustCopper>] as IItemStack[];
+
+for copper in coppers {
+    blast_furnace.recipeBuilder()
+        .inputs(copper, <minecraft:redstone>)
+        .outputs(<metaitem:ingotRedAlloy> * 2)
+        .property("temperature", 1200)
+        .duration(880).EUt(30).buildAndRegister();
+
+    alloy.findRecipe(16, [<minecraft:redstone> * 4, copper], [null]).remove();
+    alloy.recipeBuilder()
+        .inputs(<minecraft:redstone> * 2, copper)
+        .outputs(<metaitem:ingotRedAlloy>)
+        .duration(100).EUt(16).buildAndRegister();
+}
+
+blast_furnace.findRecipe(120, [<minecraft:redstone>, <metaitem:ingotCopper>], [null]).remove();
+blast_furnace.findRecipe(120, [<minecraft:redstone>, <metaitem:dustCopper>], [null]).remove();
 


### PR DESCRIPTION
Updates Gregtech CE to 1.13.681 and SoG to 2.17.0

Notable recipe changes:
- Tetrafluoroethylene and Hypochlorous Acid now output Hydrochloric Acid instead of the Diluted form
- Yttrium Barium Cuprate dust was changed to a mixer recipe and now incorporates oxygen
- Additional recipes added in the Chemistry PR, https://github.com/GregTechCE/GregTech/pull/1492 that are interesting
- Tetranitromethane got further changes, somewhat offset by the addition of a CT recipe
- Nickel Zinc Ferrite EBF recipe was change to be longer, take more input, and produce more
- Some recipes gained integrated circuits

There could be some questbook changes due to the recipes changes, such as adding a snippet about the more efficient Red Alloy, or adding a snippet about the new Tetranitromethane recipe option.

Note: It is an option to go with the vanilla gtce Annealed Copper EBF recipe now, similar to what we did with NZF in this update, as we change minimal stuff

Closes #714, Closes #711, Closes #710