### PR TITLE
Suggested fix for Advanced Dislocator NBT

### DIFF
--- a/overrides/config/brandon3055/CustomFusionRecipes.json
+++ b/overrides/config/brandon3055/CustomFusionRecipes.json
@@ -318,5 +318,27 @@
 			"draconicevolution:chaos_shard",
 			"draconicevolution:chaos_shard"
 		]
-	}
+	},
+	{
+        "mode": "REMOVE",
+        "result": "draconicevolution:dislocator_advanced",
+        "catalyst": "draconicevolution:dislocator"
+    },
+    {
+        "mode": "ADD",
+        "result": "draconicevolution:dislocator_advanced,1,0,{}",
+        "catalyst": "draconicevolution:dislocator",
+        "energy": 10000000,
+        "tier": 2,
+        "ingredients": [
+            "ore:enderpearl",
+            "ore:ingotDraconium",
+            "ore:enderpearl",
+            "ore:ingotDraconium",
+            "ore:enderpearl",
+            "ore:ingotDraconium",
+            "ore:dragonEgg",
+            "ore:ingotDraconium"
+        ]
+    }
 ]


### PR DESCRIPTION
This is a fix for Advanced Dislocators changing NBT from no NBT to "0 tags" suggested by Talchas. He was not able to identify what exactly caused the shift, and suggested a race condition of some sort.

The solution provided here is to ensure that the advanced dislocator always crafts with the NBT "0 tags"