### PR TITLE
Fix Draconium Ore not being highlighted by scanner

### DIFF
--- a/overrides/config/scannable.cfg
+++ b/overrides/config/scannable.cfg
@@ -424,6 +424,8 @@ general {
 
         glowstone=0xE9E68E
 
+        oreDraconium=0xc334eb
+
      >
 
     # Ore dictionary entries considered common ores, requiring the common ore scanner module.
@@ -628,6 +630,8 @@ general {
     # You can look up the properties (as well as name and mod id) in the F3 debug overlay
     # in the bottom right.
     S:statesRare <
+        draconicevolution:draconium_ore[type=nether]
+        draconicevolution:draconium_ore[type=end]    
      >
 
     # The list of structures the structure module scans for.


### PR DESCRIPTION
Closes #722 

Draconium ore was being a bit special and required specific definitions for the nether and end variants