### PR TITLE
Switch to Dimensional Edibles: Omnifactory Edition

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -523,7 +523,7 @@
     },
     {
       "projectID": 431982,
-      "fileID": 3270146,
+      "fileID": 3334507,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -522,8 +522,8 @@
       "required": true
     },
     {
-      "projectID": 280570,
-      "fileID": 2697259,
+      "projectID": 431982,
+      "fileID": 3270146,
       "required": true
     },
     {

--- a/overrides/config/DimensionalEdibles.cfg
+++ b/overrides/config/DimensionalEdibles.cfg
@@ -2,8 +2,14 @@
 
 dimensionaledibles {
 
+    ##########################################################################################################
+    # general
+    #--------------------------------------------------------------------------------------------------------#
+    # The Category for general features of the mod
+    ##########################################################################################################
+
     general {
-        # Set to true to enable Custom Cake.
+        # Set to true to enable Custom Apple.
         B:customApple=false
 
         # Set to true to enable custom Cakes.
@@ -12,25 +18,42 @@ dimensionaledibles {
         # Set to true to enable End Cake.
         B:endCake=true
 
-        # Set to true to enable Ender Cake.
+        # Set to true to enable Ender Apple.
         B:enderApple=false
 
-        # Set to true to enable Nether Cake.
+        # Set to true to enable Nether Apple.
         B:netherApple=false
 
         # Set to true to enable Nether Cake.
         B:netherCake=true
 
-        # Set to true to enable Overworld Cake.
+        # Required operator level to invalidate stored cake spawning position
+        # Min: 1
+        # Max: 4
+        I:operatorInvalidationLevel=1
+
+        # Set to true to enable Overworld Apple.
         B:overworldApple=false
 
         # Set to true to enable Overworld Cake.
         B:overworldCake=true
     }
 
+    ##########################################################################################################
+    # tweaks
+    #--------------------------------------------------------------------------------------------------------#
+    # The category for tweaking behaviors of mod features
+    ##########################################################################################################
+
     tweaks {
         # Set to true to disable the activation of vanilla End Portal.
         B:disableVanillaEndPortal=true
+
+        ##########################################################################################################
+        # endcake
+        #--------------------------------------------------------------------------------------------------------#
+        # The category for dealing with the End Cake
+        ##########################################################################################################
 
         endcake {
             # Set to true to make the End Cake consume fuel.
@@ -45,25 +68,63 @@ dimensionaledibles {
             # Set to true to use custom coordinates for the teleportation.
             B:useCustomCoords=false
 
+            ##########################################################################################################
+            # customcoords
+            #--------------------------------------------------------------------------------------------------------#
+            # Define the custom spawn coordinates
+            ##########################################################################################################
+
             customcoords {
+                # The X spawn coordinate
                 D:x=0.0
+
+                # The Y spawn coordinate
+                # Min: 0.0
+                # Max: 255.0
                 D:y=64.0
+
+                # The Z spawn coordinate
                 D:z=0.0
             }
 
         }
+
+        ##########################################################################################################
+        # enderapple
+        #--------------------------------------------------------------------------------------------------------#
+        # The category for dealing with the End Apple
+        ##########################################################################################################
 
         enderapple {
             # Set to true to use custom coordinates for the teleportation.
             B:useCustomCoords=false
 
+            ##########################################################################################################
+            # customcoords
+            #--------------------------------------------------------------------------------------------------------#
+            # Define the custom spawn coordinates
+            ##########################################################################################################
+
             customcoords {
+                # The X spawn coordinate
                 D:x=0.0
+
+                # The Y spawn coordinate
+                # Min: 0.0
+                # Max: 255.0
                 D:y=64.0
+
+                # The Z spawn coordinate
                 D:z=0.0
             }
 
         }
+
+        ##########################################################################################################
+        # nethercake
+        #--------------------------------------------------------------------------------------------------------#
+        # The category for dealing with the Nether Cake
+        ##########################################################################################################
 
         nethercake {
             # Set to true to make the Nether Cake consume fuel.
@@ -78,25 +139,63 @@ dimensionaledibles {
             # Set to true to use custom coordinates for the teleportation.
             B:useCustomCoords=false
 
+            ##########################################################################################################
+            # customcoords
+            #--------------------------------------------------------------------------------------------------------#
+            # Define the custom spawn coordinates
+            ##########################################################################################################
+
             customcoords {
+                # The X spawn coordinate
                 D:x=0.0
+
+                # The Y spawn coordinate
+                # Min: 0.0
+                # Max: 255.0
                 D:y=64.0
+
+                # The Z spawn coordinate
                 D:z=0.0
             }
 
         }
+
+        ##########################################################################################################
+        # netherapple
+        #--------------------------------------------------------------------------------------------------------#
+        # The category for dealing with the Nether Apple
+        ##########################################################################################################
 
         netherapple {
             # Set to true to use custom coordinates for the teleportation.
             B:useCustomCoords=false
 
+            ##########################################################################################################
+            # customcoords
+            #--------------------------------------------------------------------------------------------------------#
+            # Define the custom spawn coordinates
+            ##########################################################################################################
+
             customcoords {
+                # The X spawn coordinate
                 D:x=0.0
+
+                # The Y spawn coordinate
+                # Min: 0.0
+                # Max: 255.0
                 D:y=64.0
+
+                # The Z spawn coordinate
                 D:z=0.0
             }
 
         }
+
+        ##########################################################################################################
+        # overworldcake
+        #--------------------------------------------------------------------------------------------------------#
+        # The category dealing with the Overworld Cake
+        ##########################################################################################################
 
         overworldcake {
             # Set to true to make the Overworld Cake consume fuel.
@@ -111,17 +210,36 @@ dimensionaledibles {
             # Set to true to use custom coordinates for the teleportation.
             B:useCustomCoords=false
 
-            # Set to true to make the Overworld Apple teleport players to world spawn.
+            # Set to true to make the Overworld Cake teleport players to world spawn.
             # Otherwise, it will use the cached position.
             B:useWorldSpawn=false
 
+            ##########################################################################################################
+            # customcoords
+            #--------------------------------------------------------------------------------------------------------#
+            # Define the custom spawn coordinates
+            ##########################################################################################################
+
             customcoords {
+                # The X spawn coordinate
                 D:x=0.0
+
+                # The Y spawn coordinate
+                # Min: 0.0
+                # Max: 255.0
                 D:y=64.0
+
+                # The Z spawn coordinate
                 D:z=0.0
             }
 
         }
+
+        ##########################################################################################################
+        # overworldapple
+        #--------------------------------------------------------------------------------------------------------#
+        # The category for dealing with the Overworld Apple
+        ##########################################################################################################
 
         overworldapple {
             # Set to true to use custom coordinates for the teleportation.
@@ -131,13 +249,32 @@ dimensionaledibles {
             # Otherwise, it will use the cached position.
             B:useWorldSpawn=false
 
+            ##########################################################################################################
+            # customcoords
+            #--------------------------------------------------------------------------------------------------------#
+            # Define the custom spawn coordinates
+            ##########################################################################################################
+
             customcoords {
+                # The X spawn coordinate
                 D:x=0.0
+
+                # The Y spawn coordinate
+                # Min: 0.0
+                # Max: 255.0
                 D:y=64.0
+
+                # The Z spawn coordinate
                 D:z=0.0
             }
 
         }
+
+        ##########################################################################################################
+        # customedible
+        #--------------------------------------------------------------------------------------------------------#
+        # The category for defining and modifying a Custom Cake
+        ##########################################################################################################
 
         customedible {
             # Set a list of custom coordinates used by Custom Cakes / Apples, this is optional.
@@ -154,6 +291,12 @@ dimensionaledibles {
             S:dimensions <
                 119, Void World
              >
+
+            ##########################################################################################################
+            # customcake
+            #--------------------------------------------------------------------------------------------------------#
+            # Customization of Custom Cake features
+            ##########################################################################################################
 
             customcake {
                 # Set to true to make all Custom Cakes consume fuel.

--- a/overrides/scripts/Alchemy.zs
+++ b/overrides/scripts/Alchemy.zs
@@ -49,8 +49,6 @@ recipes.addShaped(<dimensionaledibles:nether_cake>, [[<gregtech:meta_item_1:2333
 recipes.addShaped(<dimensionaledibles:end_cake>, [[<ore:dustEndstone>,<ore:dustEndstone>,<ore:dustEndstone>], [<minecraft:ender_eye>, <enderio:item_material:70>, <minecraft:ender_eye>],[<gregtech:meta_item_1:12231>,<gregtech:meta_item_1:12231>,<gregtech:meta_item_1:12231>]]);
 
 //Void World Cake
-//recipes.addShaped(<dimensionaledibles:custom_cake>.withTag({dimID: 119, cakeName: "Void World"}), [[<actuallyadditions:item_crystal>,<actuallyadditions:item_crystal:1>,<actuallyadditions:item_crystal:4>], [<forestry:crafting_material>, <enderio:item_material:70>, <forestry:crafting_material>],[<gregtech:meta_item_1:12001>,<gregtech:meta_item_1:12001>,<gregtech:meta_item_1:12001>]]);
-
 makeShaped("of_void_cake", <dimensionaledibles:custom_cake>.withTag({dimID: 119, cakeName: "Void World"}),
 	["ABC",
 	 "DED",

--- a/overrides/scripts/Alchemy.zs
+++ b/overrides/scripts/Alchemy.zs
@@ -1,7 +1,9 @@
 import mods.gregtech.recipe.RecipeMap;
 import mods.gregtech.material.MaterialRegistry;
 import crafttweaker.item.IItemStack;
-import mods.inspirations.Cauldron;  
+import mods.inspirations.Cauldron;
+
+import scripts.CommonVars.makeShaped as makeShaped;
 
 
 //Wooden Gear
@@ -19,7 +21,7 @@ recipes.addShaped(<thermalfoundation:tool.shears_wood>, [[null,<minecraft:stick>
 //Rubber Tree
 recipes.addShapeless(<gregtech:sapling>, [<ore:treeSapling>,<gregtech:meta_item_1:32627>]);
 
-//Fertilizer 
+//Fertilizer
 recipes.remove(<forestry:fertilizer_compound>);
 recipes.addShaped(<forestry:fertilizer_compound> * 8, [[<minecraft:sand>,<gregtech:meta_item_1:8226>,<minecraft:sand>]]);
 
@@ -39,21 +41,25 @@ recipes.addShaped(<minecraft:cake>, [[<minecraft:milk_bucket> | <ceramics:clay_b
 
 //Overworld Cake
 recipes.addShaped(<dimensionaledibles:overworld_cake>, [[<minecraft:redstone>, <gregtech:meta_item_1:2026>, <minecraft:redstone>], [<ore:treeSapling>, <enderio:item_material:70>, <ore:treeSapling>],[<gregtech:meta_item_2:32570>,<minecraft:diamond>,<gregtech:meta_item_2:32570>]]);
-<dimensionaledibles:overworld_cake>.addTooltip(format.darkAqua(format.italic("Refill using Oak Saplings.")));
 
 //Nether Cake
 recipes.addShaped(<dimensionaledibles:nether_cake>, [[<gregtech:meta_item_1:2333>,<gregtech:meta_item_1:2333>,<gregtech:meta_item_1:2333>], [<minecraft:obsidian>, <enderio:item_material:70>, <minecraft:obsidian>],[<minecraft:soul_sand>,<minecraft:soul_sand>,<minecraft:soul_sand>]]);
-<dimensionaledibles:nether_cake>.addTooltip(format.darkAqua(format.italic("Refill using Obsidian.")));
 
 //End Cake
 recipes.addShaped(<dimensionaledibles:end_cake>, [[<ore:dustEndstone>,<ore:dustEndstone>,<ore:dustEndstone>], [<minecraft:ender_eye>, <enderio:item_material:70>, <minecraft:ender_eye>],[<gregtech:meta_item_1:12231>,<gregtech:meta_item_1:12231>,<gregtech:meta_item_1:12231>]]);
-<dimensionaledibles:end_cake>.addTooltip(format.darkAqua(format.italic("Refill using Eyes of Ender.")));
 
-//Voidworld Cake
-recipes.addShaped(<dimensionaledibles:custom_cake>.withTag({dimID: 119, cakeName: "Void World"}), [[<actuallyadditions:item_crystal>,<actuallyadditions:item_crystal:1>,<actuallyadditions:item_crystal:4>], [<forestry:crafting_material>, <enderio:item_material:70>, <forestry:crafting_material>],[<gregtech:meta_item_1:12001>,<gregtech:meta_item_1:12001>,<gregtech:meta_item_1:12001>]]);
-<dimensionaledibles:custom_cake>.withTag({dimID: 119, cakeName: "Void World"}).addTooltip(format.darkAqua(format.italic("Refill using Pulsating Dust.")));
+//Void World Cake
+//recipes.addShaped(<dimensionaledibles:custom_cake>.withTag({dimID: 119, cakeName: "Void World"}), [[<actuallyadditions:item_crystal>,<actuallyadditions:item_crystal:1>,<actuallyadditions:item_crystal:4>], [<forestry:crafting_material>, <enderio:item_material:70>, <forestry:crafting_material>],[<gregtech:meta_item_1:12001>,<gregtech:meta_item_1:12001>,<gregtech:meta_item_1:12001>]]);
 
-mods.jei.JEI.addItem(<dimensionaledibles:custom_cake>.withTag({dimID: 119, cakeName: "Void World"}));
-
-
-
+makeShaped("of_void_cake", <dimensionaledibles:custom_cake>.withTag({dimID: 119, cakeName: "Void World"}),
+	["ABC",
+	 "DED",
+	 "FFF"],
+	{ A : <actuallyadditions:item_crystal:0>,	// Restonia Crystal
+	  B : <actuallyadditions:item_crystal:1>,	// Palis Crystal
+	  C : <actuallyadditions:item_crystal:4>,	// Emeradic Crystal
+	  D : <forestry:crafting_material>,			// Pulsating Dust
+	  E : <enderio:item_material:70>,			// Cake Base
+	  F : <metaitem:plateAluminium>
+	}
+);


### PR DESCRIPTION
Fixes #616 and any duplicates of the same.

- Switch to our fork of Dimensional Edibles to fix spawn-below-map and spawn-in-lava issues. Players need to use the invalidate command `/de invalidate PlayerName dimID` to clear bad cached spawn positions for dimensions they have issues with. This command requires a configurable tier of Operator level to execute on a dedicated server.

- Remove hard-coded fuel tooltips from `Alchemy.zs` since DE:OE now displays them itself

- Remove forced registration of Void Cake in JEI since DE:OE will register that itself (at least following changes in [DE:OE PR #24](https://github.com/OmnifactoryDevs/DimensionalEdibles/pull/24))

- Clean up the Void Cake recipe and some dangling whitespace in `Alchemy.zs`

Known potential issues: [DE:OE PR #24](https://github.com/OmnifactoryDevs/DimensionalEdibles/pull/24) may cause void cakes placed in the world to disappear. Subsequently placed cakes should work perfectly fine.