### PR TITLE
Remove recipes for SFT items and add refunds

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -210,19 +210,6 @@ recipes.addShaped(<gregtech:meta_item_1:32640>, [
 	[<ore:cableGtSingleTin>, <gregtech:meta_item_1:14197>,<gregtech:meta_item_1:14197>],
 	[<ore:cableGtSingleTin>, <gregtech:meta_item_1:32600>, <gregtech:meta_item_2:26197>]]);
 
-<simplefluidtanks:wrench>.displayName = "Multiblock Fluid Tank Wrench";
-<simplefluidtanks:tankitem>.displayName = "Multiblock Fluid Tank Block";
-<simplefluidtanks:valveitem>.displayName = "Multiblock Fluid Tank Valve";
-recipes.remove(<simplefluidtanks:tankitem>);
-recipes.addShaped(<simplefluidtanks:tankitem> * 4, [
-	[<gregtech:meta_item_1:12033>, <minecraft:glass>, <gregtech:meta_item_1:12033>],
-	[<minecraft:glass>, null, <minecraft:glass>],
-	[<gregtech:meta_item_1:12033>, <minecraft:glass>, <gregtech:meta_item_1:12033>]]);
-recipes.remove(<simplefluidtanks:valveitem>);
-recipes.addShaped(<simplefluidtanks:valveitem>, [
-	[null, <minecraft:lever>],
-	[<simplefluidtanks:tankitem>, <gregtech:fluid_pipe:2095>]]);
-
 //Fluid Conduit
 mods.jei.JEI.removeAndHide(<enderio:item_liquid_conduit>);
 recipes.remove(<enderio:item_liquid_conduit:1>);

--- a/overrides/scripts/SimpleFluidTanks.zs
+++ b/overrides/scripts/SimpleFluidTanks.zs
@@ -1,0 +1,25 @@
+import crafttweaker.item.IItemStack;
+import crafttweaker.mods.IMod;
+
+// A Temporary file, used to create refund recipes for Simple Fluid Tanks before its eventual removal
+
+
+val sft as IMod = loadedMods["simplefluidtanks"];
+
+if(!isNull(sft)) {
+	val sftItems as IItemStack[] = sft.items;
+
+	for item in sftItems {
+		item.addTooltip(format.red("This item will be removed in the next update"));
+	}
+
+}
+
+recipes.remove(<simplefluidtanks:tankitem>);
+recipes.addShapeless(<metaitem:plateIron>, [<simplefluidtanks:tankitem>]);
+
+recipes.remove(<simplefluidtanks:valveitem>);
+recipes.addShapeless(<gregtech:fluid_pipe:2095>, [<simplefluidtanks:valveitem>]);
+
+recipes.remove(<simplefluidtanks:wrench>);
+recipes.addShapeless(<minecraft:iron_ingot> * 4, [<simplefluidtanks:wrench>]);

--- a/overrides/scripts/SimpleFluidTanks.zs
+++ b/overrides/scripts/SimpleFluidTanks.zs
@@ -15,6 +15,10 @@ if(!isNull(sft)) {
 
 }
 
+<simplefluidtanks:wrench>.displayName = "Multiblock Fluid Tank Wrench";
+<simplefluidtanks:tankitem>.displayName = "Multiblock Fluid Tank Block";
+<simplefluidtanks:valveitem>.displayName = "Multiblock Fluid Tank Valve";
+
 recipes.remove(<simplefluidtanks:tankitem>);
 recipes.addShapeless(<metaitem:plateIron>, [<simplefluidtanks:tankitem>]);
 


### PR DESCRIPTION
Removes the recipes for Simple Fluid Tanks items and adds refund recipes, in preperation for removing the mod in the next release version.

Also adds tooltips stating that the mod is going to be removed in future pack versions.

Addresses some of #706 