### PR TITLE
Allow for one clay dust to turn into one clay ball

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -69,6 +69,7 @@ recipes.addShapeless(<minecraft:gravel>, [<minecraft:cobblestone>, <gregtech:met
 recipes.addShapeless(<minecraft:sand>, [<minecraft:gravel>, <gregtech:meta_tool:12>]);
 recipes.addShapeless(<contenttweaker:block_dust>, [<minecraft:sand>, <gregtech:meta_tool:12>]);
 recipes.addShapeless(<minecraft:clay>, [<contenttweaker:block_dust>,<minecraft:water_bucket>]);
+recipes.addShapeless(<minecraft:clay_ball>, [<gregtech:meta_item_1:2105>]);
 furnace.addRecipe(<forestry:crafting_material>, <gregtech:meta_item_1:2193>, 0.0);
 recipes.addShapeless(<minecraft:gravel>, [<minecraft:cobblestone>, <gregtech:meta_tool:12>]);
 

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -69,7 +69,7 @@ recipes.addShapeless(<minecraft:gravel>, [<minecraft:cobblestone>, <gregtech:met
 recipes.addShapeless(<minecraft:sand>, [<minecraft:gravel>, <gregtech:meta_tool:12>]);
 recipes.addShapeless(<contenttweaker:block_dust>, [<minecraft:sand>, <gregtech:meta_tool:12>]);
 recipes.addShapeless(<minecraft:clay>, [<contenttweaker:block_dust>,<minecraft:water_bucket>]);
-recipes.addShapeless(<minecraft:clay_ball>, [<gregtech:meta_item_1:2105>]);
+recipes.addShaped(<minecraft:clay_ball>, [[null, null], [<gregtech:meta_item_1:2105>, null]]);
 furnace.addRecipe(<forestry:crafting_material>, <gregtech:meta_item_1:2193>, 0.0);
 recipes.addShapeless(<minecraft:gravel>, [<minecraft:cobblestone>, <gregtech:meta_tool:12>]);
 


### PR DESCRIPTION
Four clay dust can already craft into one clay block, which can then break down into four clay balls. It would make sense that a pile of clay dust can be crafted into into a clay ball.