### PR TITLE
Replace DWG with DWG: OE

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -747,8 +747,8 @@
       "required": true
     },
     {
-      "projectID": 241140,
-      "fileID": 2499252,
+      "projectID": 490698,
+      "fileID": 3337685,
       "required": true
     },
     {


### PR DESCRIPTION
This PR replaces [Default World Generator Port](https://www.curseforge.com/minecraft/mc-mods/default-world-generator-port) with [Default World Generator: Omnifactory Edition](https://www.curseforge.com/minecraft/mc-mods/default-world-generator-oe).

In particular, it removes server-side world generation prompts (completely, as a temporary solution), making it possible to actually specify custom settings in `server.properties`.