### PR TITLE
Fix incorrect and missing Scanner highlighting

### DIFF
--- a/overrides/config/scannable.cfg
+++ b/overrides/config/scannable.cfg
@@ -113,6 +113,14 @@ general {
         orePhosphor=0xd1bc00
         oreGravelApatite=0xa0c9eb
         oreGravelPhosphor=0xd1bc00
+        oreMarbleApatite=0xa0c9eb
+        oreMarblePhosphor=0xd1bc00
+        oreBlackgraniteApatite=0xa0c9eb
+        oreBlackgranitePhosphor=0xd1bc00
+        oreRedgraniteApatite=0xa0c9eb
+        oreRedgranitePhosphor=0xd1bc00
+        oreBasaltApatite=0xa0c9eb
+        oreBasaltPhosphor=0xd1bc00
 
         #Bauxite Veins
         #vibrant sky blue
@@ -123,18 +131,43 @@ general {
         oreGravelBauxite=0x0095ff
         oreGravelAluminium=0x0095ff
         oreGravelIlmenite=0x0095ff
+        oreMarbleBauxite=0x0095ff
+        oreMarbleAluminium=0x0095ff
+        oreMarbleIlmenite=0x0095ff
+        oreBlackgraniteBauxite=0x0095ff
+        oreBlackgraniteAluminium=0x0095ff
+        oreBlackgraniteIlmenite=0x0095ff
+        oreRedgraniteBauxite=0x0095ff
+        oreRedgraniteAluminium=0x0095ff
+        oreRedgraniteIlmenite=0x0095ff
+        oreBasaltBauxite=0x0095ff
+        oreBasaltAluminium=0x0095ff
+        oreBasaltIlmenite=0x0095ff
 
-        #Berylium Veins
+
+        #Beryllium Veins
         #vibrant green
-        oreBerylium=0x1ea300
+        oreBeryllium=0x1ea300
         oreThorium=0x1ea300
         oreEmerald=0x1ea300
-        oreGravelBerylium=0x1ea300
+        oreGravelBeryllium=0x1ea300
         oreGravelThorium=0x1ea300
         oreGravelEmerald=0x1ea300
-        oreEndstoneBerylium=0x1ea300
+        oreEndstoneBeryllium=0x1ea300
         oreEndstoneThorium=0x1ea300
         oreEndstoneEmerald=0x1ea300
+        oreMarbleBeryllium=0x1ea300
+        oreMarbleThorium=0x1ea300
+        oreMarbleEmerald=0x1ea300
+        oreBlackgraniteBeryllium=0x1ea300
+        oreBlackgraniteThorium=0x1ea300
+        oreBlackgraniteEmerald=0x1ea300
+        oreRedgraniteBeryllium=0x1ea300
+        oreRedgraniteThorium=0x1ea300
+        oreRedgraniteEmerald=0x1ea300
+        oreBasaltBeryllium=0x1ea300
+        oreBasaltThorium=0x1ea300
+        oreBasaltEmerald=0x1ea300
 
         #Lignite/Coal Veins
         #brown + black
@@ -142,6 +175,14 @@ general {
         oreCoal=0x999999
         oreGravelLignite=0xad8657
         oreGravelCoal=0x999999
+        oreMarbleLignite=0xad8657
+        oreMarbleCoal=0x999999
+        oreBlackgraniteLignite=0xad8657
+        oreBlackgraniteCoal=0x999999
+        oreRedgraniteLignite=0xad8657
+        oreRedgraniteCoal=0x999999
+        oreBasaltLignite=0xad8657
+        oreBasaltCoal=0x999999
 
         #Copper Veins
         #vibrant orange
@@ -154,6 +195,18 @@ general {
         oreNetherrackCopper=0xff7b00
         oreNetherrackChalcopyrite=0xff7b00
         oreNetherrackIron=0xff7b00
+        oreMarbleCopper=0xff7b00
+        oreMarbleChalcopyrite=0xff7b00
+        oreMarbleIron=0xff7b00
+        oreBlackgraniteCopper=0xff7b00
+        oreBlackgraniteChalcopyrite=0xff7b00
+        oreBlackgraniteIron=0xff7b00
+        oreRedgraniteCopper=0xff7b00
+        oreRedgraniteChalcopyrite=0xff7b00
+        oreRedgraniteIron=0xff7b00
+        oreBasaltCopper=0xff7b00
+        oreBasaltChalcopyrite=0xff7b00
+        oreBasaltIron=0xff7b00
 
         #Diamond Veins
         #vibrant cyan
@@ -162,6 +215,14 @@ general {
         #oreCoal= defined elsewhere
         oreGravelGraphite=0x00ffff
         oreGravelDiamond=0x00ffff
+        oreMarbleGraphite=0x00ffff
+        oreMarbleDiamond=0x00ffff
+        oreBlackgraniteGraphite=0x00ffff
+        oreBlackgraniteDiamond=0x00ffff
+        oreRedgraniteGraphite=0x00ffff
+        oreRedgraniteDiamond=0x00ffff
+        oreBasaltGraphite=0x00ffff
+        oreBasaltDiamond=0x00ffff
 
         #Galena Veins
         #silver and purple
@@ -171,6 +232,18 @@ general {
         oreGravelGalena=0x8d44db
         oreGravelSilver=0xedfffe
         oreGravelLead=0x8d44db
+        oreMarbleGalena=0x8d44db
+        oreMarbleSilver=0xedfffe
+        oreMarbleLead=0x8d44db
+        oreBlackgraniteGalena=0x8d44db
+        oreBlackgraniteSilver=0xedfffe
+        oreBlackgraniteLead=0x8d44db
+        oreRedgraniteGalena=0x8d44db
+        oreRedgraniteSilver=0xedfffe
+        oreRedgraniteLead=0x8d44db
+        oreBasaltGalena=0x8d44db
+        oreBasaltSilver=0xedfffe
+        oreBasaltLead=0x8d44db
 
         #Iron Veins
         #salmon pink
@@ -186,6 +259,22 @@ general {
         oreNetherrackBrownLimonite=0xffabab
         oreNetherrackBandedIron=0xffabab
         oreNetherrackMalachite=0xffabab
+        oreMarbleYellowLimonite=0xffabab
+        oreMarbleBrownLimonite=0xffabab
+        oreMarbleBandedIron=0xffabab
+        oreMarbleMalachite=0xffabab
+        oreBlackgraniteYellowLimonite=0xffabab
+        oreBlackgraniteBrownLimonite=0xffabab
+        oreBlackgraniteBandedIron=0xffabab
+        oreBlackgraniteMalachite=0xffabab
+        oreRedgraniteYellowLimonite=0xffabab
+        oreRedgraniteBrownLimonite=0xffabab
+        oreRedgraniteBandedIron=0xffabab
+        oreRedgraniteMalachite=0xffabab
+        oreBasaltYellowLimonite=0xffabab
+        oreBasaltBrownLimonite=0xffabab
+        oreBasaltBandedIron=0xffabab
+        oreBasaltMalachite=0xffabab
 
         #Lapis Veins
         #vibrant blue
@@ -201,6 +290,22 @@ general {
         oreEndstoneSodalite=0x0000ff
         oreEndstoneCalcite=0x0000ff
         oreEndstoneLapis=0x0000ff
+        oreMarbleLazurite=0x0000ff
+        oreMarbleSodalite=0x0000ff
+        oreMarbleCalcite=0x0000ff
+        oreMarbleLapis=0x0000ff
+        oreBlackgraniteLazurite=0x0000ff
+        oreBlackgraniteSodalite=0x0000ff
+        oreBlackgraniteCalcite=0x0000ff
+        oreBlackgraniteLapis=0x0000ff
+        oreRedgraniteLazurite=0x0000ff
+        oreRedgraniteSodalite=0x0000ff
+        oreRedgraniteCalcite=0x0000ff
+        oreRedgraniteLapis=0x0000ff
+        oreBasaltLazurite=0x0000ff
+        oreBasaltSodalite=0x0000ff
+        oreBasaltCalcite=0x0000ff
+        oreBasaltLapis=0x0000ff
 
         #Magnetite Veins
         #vibrant yellow
@@ -214,6 +319,18 @@ general {
         oreNetherrackMagnetite=0xffff00
         oreNetherrackVanadiumMagnetite=0xffff00
         oreNetherrackGold=0xffff00
+        oreMarbleMagnetite=0xffff00
+        oreMarbleVanadiumMagnetite=0xffff00
+        oreMarbleGold=0xffff00
+        oreBlackgraniteMagnetite=0xffff00
+        oreBlackgraniteVanadiumMagnetite=0xffff00
+        oreBlackgraniteGold=0xffff00
+        oreRedgraniteMagnetite=0xffff00
+        oreRedgraniteVanadiumMagnetite=0xffff00
+        oreRedgraniteGold=0xffff00
+        oreBasaltMagnetite=0xffff00
+        oreBasaltVanadiumMagnetite=0xffff00
+        oreBasaltGold=0xffff00
 
         #Manganese Veins
         #vibrant pink
@@ -229,6 +346,22 @@ general {
         oreEndstoneSpessartine=0xff007b
         oreEndstonePyrolusite=0xff007b
         oreEndstoneTantalite=0xff007b
+        oreMarbleGrossular=0xff007b
+        oreMarbleSpessartine=0xff007b
+        oreMarblePyrolusite=0xff007b
+        oreMarbleTantalite=0xff007b
+        oreBlackgraniteGrossular=0xff007b
+        oreBlackgraniteSpessartine=0xff007b
+        oreBlackgranitePyrolusite=0xff007b
+        oreBlackgraniteTantalite=0xff007b
+        oreRedgraniteGrossular=0xff007b
+        oreRedgraniteSpessartine=0xff007b
+        oreRedgranitePyrolusite=0xff007b
+        oreRedgraniteTantalite=0xff007b
+        oreBasaltGrossular=0xff007b
+        oreBasaltSpessartine=0xff007b
+        oreBasaltPyrolusite=0xff007b
+        oreBasaltTantalite=0xff007b
 
         #Molybdenite Veins
         #white and purple
@@ -241,6 +374,18 @@ general {
         oreEndstoneWulfenite=0xffffff
         oreEndstoneMolybdenite=0x6a3cb5
         oreEndstonePowellite=0x6a3cb5
+        oreMarbleWulfenite=0xffffff
+        oreMarbleMolybdenite=0x6a3cb5
+        oreMarblePowellite=0x6a3cb5
+        oreBlackgraniteWulfenite=0xffffff
+        oreBlackgraniteMolybdenite=0x6a3cb5
+        oreBlackgranitePowellite=0x6a3cb5
+        oreRedgraniteWulfenite=0xffffff
+        oreRedgraniteMolybdenite=0x6a3cb5
+        oreRedgranitePowellite=0x6a3cb5
+        oreBasaltWulfenite=0xffffff
+        oreBasaltMolybdenite=0x6a3cb5
+        oreBasaltPowellite=0x6a3cb5
 
         #Monazite Veins
         #vibrant magenta
@@ -250,6 +395,18 @@ general {
         oreGravelBastnasite=0xff00ff
         oreGravelMonazite=0xff00ff
         oreGravelNeodymium=0xff00ff
+        oreMarbleBastnasite=0xff00ff
+        oreMarbleMonazite=0xff00ff
+        oreMarbleNeodymium=0xff00ff
+        oreBlackgraniteBastnasite=0xff00ff
+        oreBlackgraniteMonazite=0xff00ff
+        oreBlackgraniteNeodymium=0xff00ff
+        oreRedgraniteBastnasite=0xff00ff
+        oreRedgraniteMonazite=0xff00ff
+        oreRedgraniteNeodymium=0xff00ff
+        oreBasaltBastnasite=0xff00ff
+        oreBasaltMonazite=0xff00ff
+        oreBasaltNeodymium=0xff00ff
 
         #Nickel Veins
         #vibrant teal
@@ -269,11 +426,32 @@ general {
         oreNetherrackPentlandite=0x00ff99
         oreNetherrackNickel=0x00ff99
         oreNetherrackCobaltite=0x00ff99
+        oreMarbleGarnierite=0x00ff99
+        oreMarblePentlandite=0x00ff99
+        oreMarbleNickel=0x00ff99
+        oreMarbleCobaltite=0x00ff99
+        oreBlackgraniteGarnierite=0x00ff99
+        oreBlackgranitePentlandite=0x00ff99
+        oreBlackgraniteNickel=0x00ff99
+        oreBlackgraniteCobaltite=0x00ff99
+        oreRedgraniteGarnierite=0x00ff99
+        oreRedgranitePentlandite=0x00ff99
+        oreRedgraniteNickel=0x00ff99
+        oreRedgraniteCobaltite=0x00ff99
+        oreBasaltGarnierite=0x00ff99
+        oreBasaltPentlandite=0x00ff99
+        oreBasaltNickel=0x00ff99
+        oreBasaltCobaltite=0x00ff99
 
         #Oilsands Veins
         #gray
         oreOilsands=0x999999
         oreGravelOilsands=0x999999
+        oreMarbleOilsands=0x999999
+        oreBlackgraniteOilsands=0x999999
+        oreRedgraniteOilsands=0x999999
+        oreBasaltOilsands=0x999999
+
 
         #Olivine Veins
         #olive green
@@ -289,6 +467,22 @@ general {
         oreEndstoneMagnesite=0x648047
         oreEndstoneOlivine=0x648047
         oreEndstoneGlauconite=0x648047
+        oreMarbleBentonite=0x648047
+        oreMarbleMagnesite=0x648047
+        oreMarbleOlivine=0x648047
+        oreMarbleGlauconite=0x648047
+        oreBlackgraniteBentonite=0x648047
+        oreBlackgraniteMagnesite=0x648047
+        oreBlackgraniteOlivine=0x648047
+        oreBlackgraniteGlauconite=0x648047
+        oreRedgraniteBentonite=0x648047
+        oreRedgraniteMagnesite=0x648047
+        oreRedgraniteOlivine=0x648047
+        oreRedgraniteGlauconite=0x648047
+        oreBasaltBentonite=0x648047
+        oreBasaltMagnesite=0x648047
+        oreBasaltOlivine=0x648047
+        oreBasaltGlauconite=0x648047
 
         #Pitchblende Veins
         #vibrant lime
@@ -298,6 +492,18 @@ general {
         oreGravelPitchblende=0xbbff00
         oreGravelUranium=0xbbff00
         oreGravelUraninite=0xbbff00
+        oreMarblePitchblende=0xbbff00
+        oreMarbleUranium=0xbbff00
+        oreMarbleUraninite=0xbbff00
+        oreBlackgranitePitchblende=0xbbff00
+        oreBlackgraniteUranium=0xbbff00
+        oreBlackgraniteUraninite=0xbbff00
+        oreRedgranitePitchblende=0xbbff00
+        oreRedgraniteUranium=0xbbff00
+        oreRedgraniteUraninite=0xbbff00
+        oreBasaltPitchblende=0xbbff00
+        oreBasaltUranium=0xbbff00
+        oreBasaltUraninite=0xbbff00
 
         #Platinum Veins
         #baby pink and baby blue
@@ -308,6 +514,14 @@ general {
         oreGravelPalladium=0xff879b
         oreEndstonePlatinum=0x6ec2ff
         oreEndstonePalladium=0xff879b
+        oreMarblePlatinum=0x6ec2ff
+        oreMarblePalladium=0xff879b
+        oreBlackgranitePlatinum=0x6ec2ff
+        oreBlackgranitePalladium=0xff879b
+        oreRedgranitePlatinum=0x6ec2ff
+        oreRedgranitePalladium=0xff879b
+        oreBasaltPlatinum=0x6ec2ff
+        oreBasaltPalladium=0xff879b
 
         #Quartz Veins
         #white-mint green
@@ -320,6 +534,22 @@ general {
         oreGravelNetherQuartz=0xc2ffd1
         oreGravelCertusQuartz=0xc2ffd1
         oreNetherrackNetherQuartz=0xc2ffd1
+        oreMarbleQuartzite=0xc2ffd1
+        oreMarbleBarite=0xc2ffd1
+        oreMarbleNetherQuartz=0xc2ffd1
+        oreMarbleCertusQuartz=0xc2ffd1
+        oreBlackgraniteQuartzite=0xc2ffd1
+        oreBlackgraniteBarite=0xc2ffd1
+        oreBlackgraniteNetherQuartz=0xc2ffd1
+        oreBlackgraniteCertusQuartz=0xc2ffd1
+        oreRedgraniteQuartzite=0xc2ffd1
+        oreRedgraniteBarite=0xc2ffd1
+        oreRedgraniteNetherQuartz=0xc2ffd1
+        oreRedgraniteCertusQuartz=0xc2ffd1
+        oreBasaltQuartzite=0xc2ffd1
+        oreBasaltBarite=0xc2ffd1
+        oreBasaltNetherQuartz=0xc2ffd1
+        oreBasaltCertusQuartz=0xc2ffd1
 
         #Redstone Veins
         #vibrant red
@@ -332,6 +562,18 @@ general {
         oreNetherrackRedstone=0xff0000
         oreNetherrackRuby=0xff0000
         oreNetherrackCinnabar=0xff0000
+        oreMarbleRedstone=0xff0000
+        oreMarbleRuby=0xff0000
+        oreMarbleCinnabar=0xff0000
+        oreBlackgraniteRedstone=0xff0000
+        oreBlackgraniteRuby=0xff0000
+        oreBlackgraniteCinnabar=0xff0000
+        oreRedgraniteRedstone=0xff0000
+        oreRedgraniteRuby=0xff0000
+        oreRedgraniteCinnabar=0xff0000
+        oreBasaltRedstone=0xff0000
+        oreBasaltRuby=0xff0000
+        oreBasaltCinnabar=0xff0000
 
         #Salt Veins
         #white and pink
@@ -344,6 +586,22 @@ general {
         oreGravelRockSalt=0xffffff
         oreGravelLepidolite=0xff007b
         oreGravelSpodumene=0xff007b
+        oreMarbleSalt=0xffffff
+        oreMarbleRockSalt=0xffffff
+        oreMarbleLepidolite=0xff007b
+        oreMarbleSpodumene=0xff007b
+        oreBlackgraniteSalt=0xffffff
+        oreBlackgraniteRockSalt=0xffffff
+        oreBlackgraniteLepidolite=0xff007b
+        oreBlackgraniteSpodumene=0xff007b
+        oreRedgraniteSalt=0xffffff
+        oreRedgraniteRockSalt=0xffffff
+        oreRedgraniteLepidolite=0xff007b
+        oreRedgraniteSpodumene=0xff007b
+        oreBasaltSalt=0xffffff
+        oreBasaltRockSalt=0xffffff
+        oreBasaltLepidolite=0xff007b
+        oreBasaltSpodumene=0xff007b
 
         #Sapphire Veins
         #purple and red
@@ -355,6 +613,22 @@ general {
         oreGravelPyrope=0xa30000
         oreGravelSaphire=0xa55cff
         oreGravelGreenSapphire=0xa55cff
+        oreMarbleAlmandine=0xa30000
+        oreMarblePyrope=0xa30000
+        oreMarbleSaphire=0xa55cff
+        oreMarbleGreenSapphire=0xa55cff
+        oreBlackgraniteAlmandine=0xa30000
+        oreBlackgranitePyrope=0xa30000
+        oreBlackgraniteSaphire=0xa55cff
+        oreBlackgraniteGreenSapphire=0xa55cff
+        oreRedgraniteAlmandine=0xa30000
+        oreRedgranitePyrope=0xa30000
+        oreRedgraniteSaphire=0xa55cff
+        oreRedgraniteGreenSapphire=0xa55cff
+        oreBasaltAlmandine=0xa30000
+        oreBasaltPyrope=0xa30000
+        oreBasaltSaphire=0xa55cff
+        oreBasaltGreenSapphire=0xa55cff
 
         #Soapstone Veins
         #pale green
@@ -365,6 +639,18 @@ general {
         oreGravelSoapstone=0x97e693
         oreGravelTalc=0x97e693
         oreGravelGlauconite=0x97e693
+        oreMarbleSoapstone=0x97e693
+        oreMarbleTalc=0x97e693
+        oreMarbleGlauconite=0x97e693
+        oreBlackgraniteSoapstone=0x97e693
+        oreBlackgraniteTalc=0x97e693
+        oreBlackgraniteGlauconite=0x97e693
+        oreRedgraniteSoapstone=0x97e693
+        oreRedgraniteTalc=0x97e693
+        oreRedgraniteGlauconite=0x97e693
+        oreBasaltSoapstone=0x97e693
+        oreBasaltTalc=0x97e693
+        oreBasaltGlauconite=0x97e693
 
         #Tetrahedrite Veins
         #red and orange
@@ -375,6 +661,14 @@ general {
         oreGravelStibnite=0xff7878
         oreNetherrackTetrahedrite=0xff7878
         oreNetherrackStibnite=0xff7878
+        oreMarbleTetrahedrite=0xff7878
+        oreMarbleStibnite=0xff7878
+        oreBlackgraniteTetrahedrite=0xff7878
+        oreBlackgraniteStibnite=0xff7878
+        oreRedgraniteTetrahedrite=0xff7878
+        oreRedgraniteStibnite=0xff7878
+        oreBasaltTetrahedrite=0xff7878
+        oreBasaltStibnite=0xff7878
 
         #Tin Veins
         #light gray
@@ -382,6 +676,14 @@ general {
         oreCassiterite=0xbcdce6
         oreGravelTin=0xbcdce6
         oreGravelCassiterite=0xbcdce6
+        oreMarbleTin=0xbcdce6
+        oreMarbleCassiterite=0xbcdce6
+        oreBlackgraniteTin=0xbcdce6
+        oreBlackgraniteCassiterite=0xbcdce6
+        oreRedgraniteTin=0xbcdce6
+        oreRedgraniteCassiterite=0xbcdce6
+        oreBasaltTin=0xbcdce6
+        oreBasaltCassiterite=0xbcdce6
 
         #Tungstate Veins
         #vibrant violet
@@ -394,6 +696,18 @@ general {
         oreEndstoneScheelite=0x7300ff
         oreEndstoneTungstate=0x7300ff
         oreEndstoneLithium=0x7300ff
+        oreMarbleScheelite=0x7300ff
+        oreMarbleTungstate=0x7300ff
+        oreMarbleLithium=0x7300ff
+        oreBlackgraniteScheelite=0x7300ff
+        oreBlackgraniteTungstate=0x7300ff
+        oreBlackgraniteLithium=0x7300ff
+        oreRedgraniteScheelite=0x7300ff
+        oreRedgraniteTungstate=0x7300ff
+        oreRedgraniteLithium=0x7300ff
+        oreBasaltScheelite=0x7300ff
+        oreBasaltTungstate=0x7300ff
+        oreBasaltLithium=0x7300ff
 
         #Zinc Veins
         #white and blue
@@ -405,6 +719,18 @@ general {
         oreGravelSphalerite=0x00a2ff
         oreNetherrackSphalerite=0x00a2ff
         oreNetherrackPyrite=0xffffff
+        oreMarbleZinc=0xffffff
+        oreMarblePyrite=0xffffff
+        oreMarbleSphalerite=0x00a2ff
+        oreBlackgraniteZinc=0xffffff
+        oreBlackgranitePyrite=0xffffff
+        oreBlackgraniteSphalerite=0x00a2ff
+        oreRedgraniteZinc=0xffffff
+        oreRedgranitePyrite=0xffffff
+        oreRedgraniteSphalerite=0x00a2ff
+        oreBasaltZinc=0xffffff
+        oreBasaltPyrite=0xffffff
+        oreBasaltSphalerite=0x00a2ff
 
         #Nether Specific
         #Nether Sulfur Veins, Bright Yellow
@@ -440,10 +766,22 @@ general {
         orePhosphor
         oreGravelApatite
         oreGravelPhosphor
+        oreMarbleApatite
+        oreMarblePhosphor
+        oreBlackgraniteApatite
+        oreBlackgranitePhosphor
+        oreRedgraniteApatite
+        oreRedgranitePhosphor
+        oreBasaltApatite
+        oreBasaltPhosphor
 
         #Copper Veins
         oreChalcopyrite
         oreGravelChalcopyrite
+        oreMarbleChalcopyrite
+        oreBlackgraniteChalcopyrite
+        oreRedgraniteChalcopyrite
+        oreBasaltChalcopyrite
 
         #Galena Veins
         oreGalena
@@ -452,6 +790,18 @@ general {
         oreGravelGalena
         oreGravelSilver
         oreGravelLead
+        oreMarbleGalena
+        oreMarbleSilver
+        oreMarbleLead
+        oreBlackgraniteGalena
+        oreBlackgraniteSilver
+        oreBlackgraniteLead
+        oreRedgraniteGalena
+        oreRedgraniteSilver
+        oreRedgraniteLead
+        oreBasaltGalena
+        oreBasaltSilver
+        oreBasaltLead
 
         #Iron Veins
         oreYellowLimonite
@@ -462,15 +812,39 @@ general {
         oreGravelBrownLimonite
         oreGravelBandedIron
         oreGravelMalachite
+        oreMarbleYellowLimonite
+        oreMarbleBrownLimonite
+        oreMarbleBandedIron
+        oreMarbleMalachite
+        oreBlackgraniteYellowLimonite
+        oreBlackgraniteBrownLimonite
+        oreBlackgraniteBandedIron
+        oreBlackgraniteMalachite
+        oreRedgraniteYellowLimonite
+        oreRedgraniteBrownLimonite
+        oreRedgraniteBandedIron
+        oreRedgraniteMalachite
+        oreBasaltYellowLimonite
+        oreBasaltBrownLimonite
+        oreBasaltBandedIron
+        oreBasaltMalachite
 
         #Lapis Veins
         oreSodalite
         oreGravelSodalite
+        oreMarbleSodalite
+        oreBlackgraniteSodalite
+        oreRedgraniteSodalite
+        oreBasaltSodalite
 
 
         #Lignite Coal Veins
         oreLignite
         oreGravelLignite
+        oreMarbleLignite
+        oreBlackgraniteLignite
+        oreRedgraniteLignite
+        oreBasaltLignite
 
         #Magnetite Veins
         oreMagnetite
@@ -481,12 +855,36 @@ general {
         oreGravelIron
         oreGravelVanadiumMagnetite
         oreGravelGold
+        oreMarbleMagnetite
+        oreMarbleIron
+        oreMarbleVanadiumMagnetite
+        oreMarbleGold
+        oreBlackgraniteMagnetite
+        oreBlackgraniteIron
+        oreBlackgraniteVanadiumMagnetite
+        oreBlackgraniteGold
+        oreRedgraniteMagnetite
+        oreRedgraniteIron
+        oreRedgraniteVanadiumMagnetite
+        oreRedgraniteGold
+        oreBasaltMagnetite
+        oreBasaltIron
+        oreBasaltVanadiumMagnetite
+        oreBasaltGold
 
         #Oilsands Vein
         oreOilsands
         oreCoal
         oreGravelOilsands
         oreGravelCoal
+        oreMarbleOilsands
+        oreMarbleCoal
+        oreBlackgraniteOilsands
+        oreBlackgraniteCoal
+        oreRedgraniteOilsands
+        oreRedgraniteCoal
+        oreBasaltOilsands
+        oreBasaltCoal
 
         #Quartz Veins
         oreQuartzite
@@ -497,6 +895,22 @@ general {
         oreGravelBarite
         oreGravelNetherQuartz
         oreGravelCertusQuartz
+        oreMarbleQuartzite
+        oreMarbleBarite
+        oreMarbleNetherQuartz
+        oreMarbleCertusQuartz
+        oreBlackgraniteQuartzite
+        oreBlackgraniteBarite
+        oreBlackgraniteNetherQuartz
+        oreBlackgraniteCertusQuartz
+        oreRedgraniteQuartzite
+        oreRedgraniteBarite
+        oreRedgraniteNetherQuartz
+        oreRedgraniteCertusQuartz
+        oreBasaltQuartzite
+        oreBasaltBarite
+        oreBasaltNetherQuartz
+        oreBasaltCertusQuartz
 
         #Redstone Veins
         oreRedstone
@@ -505,6 +919,18 @@ general {
         oreGravelRedstone
         oreGravelRuby
         oreGravelCinnabar
+        oreMarbleRedstone
+        oreMarbleRuby
+        oreMarbleCinnabar
+        oreBlackgraniteRedstone
+        oreBlackgraniteRuby
+        oreBlackgraniteCinnabar
+        oreRedgraniteRedstone
+        oreRedgraniteRuby
+        oreRedgraniteCinnabar
+        oreBasaltRedstone
+        oreBasaltRuby
+        oreBasaltCinnabar
 
         #Salt Veins
         oreSalt
@@ -515,6 +941,22 @@ general {
         oreGravelRockSalt
         oreGravelLepidolite
         oreGravelSpodumene
+        oreMarbleSalt
+        oreMarbleRockSalt
+        oreMarbleLepidolite
+        oreMarbleSpodumene
+        oreBlackgraniteSalt
+        oreBlackgraniteRockSalt
+        oreBlackgraniteLepidolite
+        oreBlackgraniteSpodumene
+        oreRedgraniteSalt
+        oreRedgraniteRockSalt
+        oreRedgraniteLepidolite
+        oreRedgraniteSpodumene
+        oreBasaltSalt
+        oreBasaltRockSalt
+        oreBasaltLepidolite
+        oreBasaltSpodumene
 
         #Soapstone Veins
         oreSoapstone
@@ -525,6 +967,22 @@ general {
         oreGravelGlauconite
         oreGravelPentlandite
         oreGravelTalc
+        oreMarbleSoapstone
+        oreMarbleGlauconite
+        oreMarblePentlandite
+        oreMarbleTalc
+        oreBlackgraniteSoapstone
+        oreBlackgraniteGlauconite
+        oreBlackgranitePentlandite
+        oreBlackgraniteTalc
+        oreRedgraniteSoapstone
+        oreRedgraniteGlauconite
+        oreRedgranitePentlandite
+        oreRedgraniteTalc
+        oreBasaltSoapstone
+        oreBasaltGlauconite
+        oreBasaltPentlandite
+        oreBasaltTalc
 
         #Tetrahedrite Veins
         oreTetrahedrite
@@ -533,12 +991,32 @@ general {
         oreGravelTetrahedrite
         oreGravelStibnite
         oreGravelCopper
+        oreMarbleTetrahedrite
+        oreMarbleStibnite
+        oreMarbleCopper
+        oreBlackgraniteTetrahedrite
+        oreBlackgraniteStibnite
+        oreBlackgraniteCopper
+        oreRedgraniteTetrahedrite
+        oreRedgraniteStibnite
+        oreRedgraniteCopper
+        oreBasaltTetrahedrite
+        oreBasaltStibnite
+        oreBasaltCopper
 
         #Tin Veins
         oreTin
         oreCassiterite
         oreGravelTin
         oreGravelCassiterite
+        oreMarbleTin
+        oreMarbleCassiterite
+        oreBlackgraniteTin
+        oreBlackgraniteCassiterite
+        oreRedgraniteTin
+        oreRedgraniteCassiterite
+        oreBasaltTin
+        oreBasaltCassiterite
 
         #Zinc Veins
         oreZinc
@@ -547,6 +1025,18 @@ general {
         oreGravelZinc
         oreGravelPyrite
         oreGravelSphalerite
+        oreMarbleZinc
+        oreMarblePyrite
+        oreMarbleSphalerite
+        oreBlackgraniteZinc
+        oreBlackgranitePyrite
+        oreBlackgraniteSphalerite
+        oreRedgraniteZinc
+        oreRedgranitePyrite
+        oreRedgraniteSphalerite
+        oreBasaltZinc
+        oreBasaltPyrite
+        oreBasaltSphalerite
 
         #Nether Veins
         #Sulfur


### PR DESCRIPTION
Fixes Beryllium not being highlighted due to a misspelling of its oredict.

Adds highlighting to variant ores added in #639 