### PR TITLE
Fixing naming inconsistencies with Black Iron Frame/Lamp, EV Electrolyzer and EV Air Collector

### DIFF
--- a/overrides/scripts/ExtendedCrafting.zs
+++ b/overrides/scripts/ExtendedCrafting.zs
@@ -6,6 +6,9 @@ import scripts.CommonVars.makeExtremeRecipe5 as makeExtremeRecipe5;
 import scripts.CommonVars.makeExtremeRecipe7 as makeExtremeRecipe7;
 import scripts.CommonVars.makeExtremeRecipe9 as makeExtremeRecipe9;
 
+<extendedcrafting:frame>.displayName = "Black Steel Frame";
+<extendedcrafting:lamp>.displayName = "Black Steel Lamp";
+
 fluid_extractor.recipeBuilder()
     .inputs([<ore:dustCryotheum>])
     .fluidOutputs([<liquid:cryotheum> * 250])

--- a/overrides/scripts/Midgame.zs
+++ b/overrides/scripts/Midgame.zs
@@ -4,6 +4,14 @@ import crafttweaker.item.IIngredient;
 import crafttweaker.data.IData;
 import scripts.CommonVars.makeShaped as makeShaped;
 
+//EV Electrolyzer
+<gregtech:machine:243>.displayName = "Advanced Electrolyzer III";
+<gregtech:machine:243>.addTooltip("Molecular Disintegrator E-4904");
+
+//EV Air Collector
+<gregtech:machine:980>.displayName = "Advanced Air Collector III";
+<gregtech:machine:980>.addTooltip("Atmosphere Collector III");
+
 recipes.addShapeless(<appliedenergistics2:network_tool>, [<ore:itemIlluminatedPanel>, <actuallyadditions:item_laser_wrench>]);
 
 furnace.addRecipe(<enderio:block_fused_glass>, <minecraft:glass>, 0.0);


### PR DESCRIPTION
This PR fixes 4 naming inconsistencies.

- Black Iron Frame/Lamp -> Black Steel Frame/Lamp
  - They are made from Black Steel, this change makes them consistent.
- Atmosphere Collector III -> Advanced Air Collector III
- Molecular Disintegrator E-4908 -> Advanced Electrolyzer III
  - I added a tooltip for this "Molecular Disintegrator E-4904" like the higher tier SoG machines. E-4904 because the IV Electrolyzer is E-4905, LuV is E-4906... 

Hopefully in the right zs files, if they aren't feel free to let me know or move them.