### PR TITLE
Suggest Change to primitive Diode recipe.

### DIFF
--- a/overrides/scripts/Electronics.zs
+++ b/overrides/scripts/Electronics.zs
@@ -146,9 +146,11 @@ recipes.addShaped(<contenttweaker:combinationcircuit>, [
 	[<ore:plateWroughtIron>, <metaitem:circuit.basic>, <ore:cableGtSingleRedAlloy>], 
 	[<metaitem:circuit.basic>, <metaitem:component.diode>, <metaitem:circuit.basic>], 
 	[<ore:cableGtSingleRedAlloy>, <metaitem:circuit.basic>, <ore:plateWroughtIron>]]);
-	
-	
-	
+
+//Diode
+assembler.findRecipe(48, [<gregtech:meta_item_2:16087> * 4, <gregtech:meta_item_1:1025>], [<liquid:plastic> * 288]).remove();
+assembler.recipeBuilder().inputs([<gregtech:meta_item_2:16189> *4, <gregtech:meta_item_1:1025>]).outputs([<gregtech:meta_item_2:32451> * 16]).duration(40).EUt(256).buildAndRegister();
+
 //Electronic Processor	
 
 <contenttweaker:electronicprocessor>.addTooltip(format.aqua(format.italic("This is the second Tier Two circuit.")));


### PR DESCRIPTION
I'm suggesting a change to the primitive Diode assembler recipe.

This is primarily done to avoid a conflict that arises when trying to craft SMD Diodes and SMD Transistors in the same machine.

Please note that the specific recipe is not finalized and probably requires some discussion if everyone agrees that changing the recipe is acceptable.

My thought behind the changes were:

Fine Annealed Copper Wire -> Fine Tin Alloy Wire - Annealed Copper happens a bit later in the chain than the time when you are manually crafting Primitive Processors (the only components that primitive Diodes are used for).  It seems more reasonable to me that you would replace the Tin Wire in the manual craft with a more advanced version of Tin, hence Tin Alloy.

288mb Polyethylene -> Removed - There are four primitive components, two of which have Rubber Sheets in the Crafting recipe (Transistor and Capacitor), and two of which don't (Diode and Resistor).  The Polyethylene in the recipe seems to replace the rubber and so in my opinion shouldn't be used to craft the Diode.  I would also suggest changing the Polyethylene sheet to liquid Polyethylene and adding a Silicon Plate to the Capacitor recipe, but that's a different issue.

MV Power -> HV Power - Crafting these in an Assembler should not be happening during progression.  Since better tier two circuits are crafted using transistors which are earlier in the progression chain, it seems that further incentivizing using those should help push the player in to quick circuit advancement.  The only real use case for the Diode Assembler recipe is for auto crafting of Primitive Processors in a Bounty Board setup, which at earliest happens at the very end of MV or during HV.  Adjusting the power requirements to match that seemed to make sense.