### PR TITLE
Remove EnderTweaker. Transition recipes to XML

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -332,11 +332,6 @@
       "required": true
     },
     {
-      "projectID": 312195,
-      "fileID": 3131262,
-      "required": true
-    },
-    {
       "projectID": 254268,
       "fileID": 3051236,
       "required": true

--- a/overrides/config/enderio/recipes/user/SliceNSplice.xml
+++ b/overrides/config/enderio/recipes/user/SliceNSplice.xml
@@ -61,6 +61,8 @@
 
 <!-- Ender Resonator -->
 
+<recipe name="Ender Resonator"><disabled/></recipe>
+
 <recipe name="Ender Resonator Omni">
     <slicing energy="20000">
       <input name="ingotSoularium"/><input name="enderio:block_enderman_skull:0"/><input name="ingotSoularium"/>
@@ -86,6 +88,8 @@
   </recipe>
 
 <!-- Z Logic Controller -->
+
+<recipe name="Controller Skull"><disabled/></recipe>
 
 <recipe name="Z Logic Controller Omni">
     <slicing energy="20000">

--- a/overrides/config/enderio/recipes/user/SliceNSplice.xml
+++ b/overrides/config/enderio/recipes/user/SliceNSplice.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<enderio:recipes xmlns:enderio="http://enderio.com/recipes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://enderio.com/recipes recipes.xsd ">
+
+<!-- Guardian Diode -->
+
+<recipe name="Guardian Diode"><disabled/></recipe>
+
+<recipe name="Guardian Diode Omni">
+    <slicing energy="20000">
+      <input name="ingotEnergeticAlloy"/><input name="gemPrismarine"/><input name="
+ingotEnergeticAlloy"/>
+      <input name="dustPrismarine"/><input name="itemSilicon"/><input name="
+dustPrismarine"/>
+      <output name="skullGuardianDiode"/>
+    </slicing>
+  </recipe>
+
+  <recipe name="Guardian Diode One Bonus Omni">
+    <slicing energy="40000">
+      <input name="ingotEnergeticAlloy"/><input name="gemPrismarine"/><input name="
+ingotEnergeticAlloy"/>
+      <input name="dustPrismarine"/><input name="gregtech:meta_item_2:32441"/><input name="
+dustPrismarine"/>
+      <output name="skullGuardianDiode" amount="2" />
+    </slicing>
+  </recipe>
+
+  <recipe name="Guardian Diode Two Bonus Omni">
+    <slicing energy="80000">
+      <input name="ingotEnergeticAlloy"/><input name="gemPrismarine"/><input name="
+ingotEnergeticAlloy"/>
+      <input name="dustPrismarine"/><input name="gregtech:meta_item_2:32442"/><input name="
+dustPrismarine"/>
+      <output name="skullGuardianDiode" amount="4"/>
+    </slicing>
+  </recipe>
+
+  
+<!-- Skeletal Contractor -->
+
+<recipe name="Skeletal Contractor"><disabled/></recipe>
+
+<recipe name="Skeletal Contractor Omni">
+    <slicing energy="20000">
+      <input name="ingotSoularium"/><input name="minecraft:skull:0"/><input name="
+ingotSoularium"/>
+      <input name="minecraft:rotten_flesh"/><input name="itemSilicon"/><input name="
+minecraft:rotten_flesh"/>
+      <output name="skullSkeletalContractor"/>
+    </slicing>
+  </recipe>
+
+  <recipe name="Skeletal Contractor One Bonus Omni">
+    <slicing energy="40000">
+      <input name="ingotSoularium"/><input name="minecraft:skull:0"/><input name="
+ingotSoularium"/>
+      <input name="minecraft:rotten_flesh"/><input name="gregtech:meta_item_2:32441"/><input name="
+minecraft:rotten_flesh"/>
+      <output name="skullSkeletalContractor" amount="2"/>
+    </slicing>
+  </recipe>
+
+  <recipe name="Skeletal Contractor Two Bonus Omni">
+    <slicing energy="80000">
+      <input name="ingotSoularium"/><input name="minecraft:skull:0"/><input name="
+ingotSoularium"/>
+      <input name="minecraft:rotten_flesh"/><input name="gregtech:meta_item_2:32442"/><input name="
+minecraft:rotten_flesh"/>
+      <output name="skullSkeletalContractor" amount="4"/>
+    </slicing>
+  </recipe>
+
+<!-- Ender Resonator -->
+
+<recipe name="Ender Resonator One Bonus Omni">
+    <slicing energy="40000">
+      <input name="ingotSoularium"/><input name="enderio:block_enderman_skull:0"
+/><input name="ingotSoularium"/>
+      <input name="gregtech:meta_item_2:32441"/><input name="ingotVibrantAlloy"/><input name="
+gregtech:meta_item_2:32441"/>
+      <output name="skullEnderResonator" amount="2"/>
+    </slicing>
+  </recipe>
+
+  <recipe name="Ender Resonator Two Bonus Omni">
+    <slicing energy="80000">
+      <input name="ingotSoularium"/><input name="enderio:block_enderman_skull:0"
+/><input name="ingotSoularium"/>
+      <input name="gregtech:meta_item_2:32442"/><input name="ingotVibrantAlloy"/><input name="
+gregtech:meta_item_2:32442"/>
+      <output name="skullEnderResonator" amount="4"/>
+    </slicing>
+  </recipe>
+
+<!-- Z Logic Controller -->
+
+<recipe name="Z Logic Controller One Bonus Omni">
+    <slicing energy="40000">
+      <input name="ingotSoularium"/><input name="minecraft:skull:2"/><input name="
+ingotSoularium"/>
+      <input name="gregtech:meta_item_2:32441"/><input name="dustRedstone"/><input name="gregtech:meta_item_2:32441"
+/>
+      <output name="skullZombieController" amount="2"/>
+    </slicing>
+  </recipe>
+
+  <recipe name="Z Logic Controller Two Bonus Omni">
+    <slicing energy="80000">
+      <input name="ingotSoularium"/><input name="minecraft:skull:2"/><input name="
+ingotSoularium"/>
+      <input name="gregtech:meta_item_2:32442"/><input name="dustRedstone"/><input name="gregtech:meta_item_2:32442"
+/>
+      <output name="skullZombieController" amount="4"/>
+    </slicing>
+  </recipe>
+
+
+  <!-- Dead End Recipe Removals -->
+
+  <recipe name="Electrode Skull"><disabled/></recipe>
+
+  <recipe name="Totemic Capacitor"><disabled/></recipe>
+
+
+</enderio:recipes>

--- a/overrides/config/enderio/recipes/user/SliceNSplice.xml
+++ b/overrides/config/enderio/recipes/user/SliceNSplice.xml
@@ -61,6 +61,14 @@
 
 <!-- Ender Resonator -->
 
+<recipe name="Ender Resonator Omni">
+    <slicing energy="20000">
+      <input name="ingotSoularium"/><input name="enderio:block_enderman_skull:0"/><input name="ingotSoularium"/>
+      <input name="itemSilicon"/><input name="ingotVibrantAlloy"/><input name="itemSilicon"/>
+      <output name="skullEnderResonator"/>
+    </slicing>
+  </recipe>
+
 <recipe name="Ender Resonator One Bonus Omni">
     <slicing energy="40000">
       <input name="ingotSoularium"/><input name="enderio:block_enderman_skull:0"/><input name="ingotSoularium"/>
@@ -79,7 +87,15 @@
 
 <!-- Z Logic Controller -->
 
-<recipe name="Z Logic Controller One Bonus Omni">
+<recipe name="Z Logic Controller Omni">
+    <slicing energy="20000">
+      <input name="ingotSoularium"/><input name="minecraft:skull:2"/><input name="ingotSoularium"/>
+      <input name="itemSilicon"/><input name="dustRedstone"/><input name="itemSilicon" />
+      <output name="skullZombieController"/>
+    </slicing>
+  </recipe>
+
+  <recipe name="Z Logic Controller One Bonus Omni">
     <slicing energy="40000">
       <input name="ingotSoularium"/><input name="minecraft:skull:2"/><input name="ingotSoularium"/>
       <input name="gregtech:meta_item_2:32441"/><input name="dustRedstone"/><input name="gregtech:meta_item_2:32441" />

--- a/overrides/config/enderio/recipes/user/SliceNSplice.xml
+++ b/overrides/config/enderio/recipes/user/SliceNSplice.xml
@@ -8,30 +8,24 @@
 
 <recipe name="Guardian Diode Omni">
     <slicing energy="20000">
-      <input name="ingotEnergeticAlloy"/><input name="gemPrismarine"/><input name="
-ingotEnergeticAlloy"/>
-      <input name="dustPrismarine"/><input name="itemSilicon"/><input name="
-dustPrismarine"/>
+      <input name="ingotEnergeticAlloy"/><input name="gemPrismarine"/><input name="ingotEnergeticAlloy"/>
+      <input name="dustPrismarine"/><input name="itemSilicon"/><input name="dustPrismarine"/>
       <output name="skullGuardianDiode"/>
     </slicing>
   </recipe>
 
   <recipe name="Guardian Diode One Bonus Omni">
     <slicing energy="40000">
-      <input name="ingotEnergeticAlloy"/><input name="gemPrismarine"/><input name="
-ingotEnergeticAlloy"/>
-      <input name="dustPrismarine"/><input name="gregtech:meta_item_2:32441"/><input name="
-dustPrismarine"/>
+      <input name="ingotEnergeticAlloy"/><input name="gemPrismarine"/><input name="ingotEnergeticAlloy"/>
+      <input name="dustPrismarine"/><input name="gregtech:meta_item_2:32441"/><input name="dustPrismarine"/>
       <output name="skullGuardianDiode" amount="2" />
     </slicing>
   </recipe>
 
   <recipe name="Guardian Diode Two Bonus Omni">
     <slicing energy="80000">
-      <input name="ingotEnergeticAlloy"/><input name="gemPrismarine"/><input name="
-ingotEnergeticAlloy"/>
-      <input name="dustPrismarine"/><input name="gregtech:meta_item_2:32442"/><input name="
-dustPrismarine"/>
+      <input name="ingotEnergeticAlloy"/><input name="gemPrismarine"/><input name="ingotEnergeticAlloy"/>
+      <input name="dustPrismarine"/><input name="gregtech:meta_item_2:32442"/><input name="dustPrismarine"/>
       <output name="skullGuardianDiode" amount="4"/>
     </slicing>
   </recipe>
@@ -43,30 +37,24 @@ dustPrismarine"/>
 
 <recipe name="Skeletal Contractor Omni">
     <slicing energy="20000">
-      <input name="ingotSoularium"/><input name="minecraft:skull:0"/><input name="
-ingotSoularium"/>
-      <input name="minecraft:rotten_flesh"/><input name="itemSilicon"/><input name="
-minecraft:rotten_flesh"/>
+      <input name="ingotSoularium"/><input name="minecraft:skull:0"/><input name="ingotSoularium"/>
+      <input name="minecraft:rotten_flesh"/><input name="itemSilicon"/><input name="minecraft:rotten_flesh"/>
       <output name="skullSkeletalContractor"/>
     </slicing>
   </recipe>
 
   <recipe name="Skeletal Contractor One Bonus Omni">
     <slicing energy="40000">
-      <input name="ingotSoularium"/><input name="minecraft:skull:0"/><input name="
-ingotSoularium"/>
-      <input name="minecraft:rotten_flesh"/><input name="gregtech:meta_item_2:32441"/><input name="
-minecraft:rotten_flesh"/>
+      <input name="ingotSoularium"/><input name="minecraft:skull:0"/><input name="ingotSoularium"/>
+      <input name="minecraft:rotten_flesh"/><input name="gregtech:meta_item_2:32441"/><input name="minecraft:rotten_flesh"/>
       <output name="skullSkeletalContractor" amount="2"/>
     </slicing>
   </recipe>
 
   <recipe name="Skeletal Contractor Two Bonus Omni">
     <slicing energy="80000">
-      <input name="ingotSoularium"/><input name="minecraft:skull:0"/><input name="
-ingotSoularium"/>
-      <input name="minecraft:rotten_flesh"/><input name="gregtech:meta_item_2:32442"/><input name="
-minecraft:rotten_flesh"/>
+      <input name="ingotSoularium"/><input name="minecraft:skull:0"/><input name="ingotSoularium"/>
+      <input name="minecraft:rotten_flesh"/><input name="gregtech:meta_item_2:32442"/><input name="minecraft:rotten_flesh"/>
       <output name="skullSkeletalContractor" amount="4"/>
     </slicing>
   </recipe>
@@ -75,20 +63,16 @@ minecraft:rotten_flesh"/>
 
 <recipe name="Ender Resonator One Bonus Omni">
     <slicing energy="40000">
-      <input name="ingotSoularium"/><input name="enderio:block_enderman_skull:0"
-/><input name="ingotSoularium"/>
-      <input name="gregtech:meta_item_2:32441"/><input name="ingotVibrantAlloy"/><input name="
-gregtech:meta_item_2:32441"/>
+      <input name="ingotSoularium"/><input name="enderio:block_enderman_skull:0"/><input name="ingotSoularium"/>
+      <input name="gregtech:meta_item_2:32441"/><input name="ingotVibrantAlloy"/><input name="gregtech:meta_item_2:32441"/>
       <output name="skullEnderResonator" amount="2"/>
     </slicing>
   </recipe>
 
   <recipe name="Ender Resonator Two Bonus Omni">
     <slicing energy="80000">
-      <input name="ingotSoularium"/><input name="enderio:block_enderman_skull:0"
-/><input name="ingotSoularium"/>
-      <input name="gregtech:meta_item_2:32442"/><input name="ingotVibrantAlloy"/><input name="
-gregtech:meta_item_2:32442"/>
+      <input name="ingotSoularium"/><input name="enderio:block_enderman_skull:0"/><input name="ingotSoularium"/>
+      <input name="gregtech:meta_item_2:32442"/><input name="ingotVibrantAlloy"/><input name="gregtech:meta_item_2:32442"/>
       <output name="skullEnderResonator" amount="4"/>
     </slicing>
   </recipe>
@@ -97,20 +81,16 @@ gregtech:meta_item_2:32442"/>
 
 <recipe name="Z Logic Controller One Bonus Omni">
     <slicing energy="40000">
-      <input name="ingotSoularium"/><input name="minecraft:skull:2"/><input name="
-ingotSoularium"/>
-      <input name="gregtech:meta_item_2:32441"/><input name="dustRedstone"/><input name="gregtech:meta_item_2:32441"
-/>
+      <input name="ingotSoularium"/><input name="minecraft:skull:2"/><input name="ingotSoularium"/>
+      <input name="gregtech:meta_item_2:32441"/><input name="dustRedstone"/><input name="gregtech:meta_item_2:32441" />
       <output name="skullZombieController" amount="2"/>
     </slicing>
   </recipe>
 
   <recipe name="Z Logic Controller Two Bonus Omni">
     <slicing energy="80000">
-      <input name="ingotSoularium"/><input name="minecraft:skull:2"/><input name="
-ingotSoularium"/>
-      <input name="gregtech:meta_item_2:32442"/><input name="dustRedstone"/><input name="gregtech:meta_item_2:32442"
-/>
+      <input name="ingotSoularium"/><input name="minecraft:skull:2"/><input name="ingotSoularium"/>
+      <input name="gregtech:meta_item_2:32442"/><input name="dustRedstone"/><input name="gregtech:meta_item_2:32442" />
       <output name="skullZombieController" amount="4"/>
     </slicing>
   </recipe>

--- a/overrides/config/enderio/recipes/user/Soulbinder.xml
+++ b/overrides/config/enderio/recipes/user/Soulbinder.xml
@@ -34,7 +34,7 @@
     </soulbinding>
   </recipe>
 
-<!-- Fligh Control Unit Recipes -->
+<!-- Flight Control Unit Recipes -->
 
   <recipe name="Soul Binder: Flight Control Bat Omni" required="true">
     <soulbinding energy="75000" levels="8" logic="NONE">

--- a/overrides/config/enderio/recipes/user/Soulbinder.xml
+++ b/overrides/config/enderio/recipes/user/Soulbinder.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<enderio:recipes xmlns:enderio="http://enderio.com/recipes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://enderio.com/recipes recipes.xsd ">
+
+  
+<!-- Token Recipes -->
+
+  <recipe name="Tank: Player Token"><disabled/></recipe>
+
+  <recipe name="Tank: Player Token Omni" required="true">
+    <soulbinding energy="25000" levels="1" logic="NONE" souls="ALL">
+      <input name="darkutils:filter" />
+      <output name="itemTokenPlayer" />
+    </soulbinding>
+  </recipe>
+
+
+  <recipe name="Soul Binder: Monster Token"><disabled/></recipe>
+
+  <recipe name="Soul Binder: Monster Token Omni" required="true">
+    <soulbinding energy="25000" levels="1" logic="NONE" souls="MONSTERS">
+      <input name="darkutils:filter:3" />
+      <output name="itemTokenMonster" />
+    </soulbinding>
+  </recipe>
+
+
+  <recipe name="Soul Binder: Animal Token"><disabled/></recipe>
+
+  <recipe name="Soul Binder: Animal Token Omni" required="true">
+    <soulbinding energy="25000" levels="1" logic="NONE" souls="ANIMALS">
+      <input name="darkutils:filter:4" />
+      <output name="itemTokenAnimal" />
+    </soulbinding>
+  </recipe>
+
+<!-- Fligh Control Unit Recipes -->
+
+  <recipe name="Soul Binder: Flight Control Bat Omni" required="true">
+    <soulbinding energy="75000" levels="8" logic="NONE">
+      <soul name="minecraft:bat" />
+      <input name="simplyjetpacks:metaitemmods:5" />
+      <output name="simplyjetpacks:metaitemmods:6" />
+    </soulbinding>
+  </recipe>
+
+  <recipe name="Soul Binder: Flight Control Ghast Omni" required="true">
+    <soulbinding energy="75000" levels="300" logic="NONE">
+      <soul name="minecraft:ghast" />
+      <input name="simplyjetpacks:metaitemmods:5" />
+      <output name="simplyjetpacks:metaitemmods:6" />
+    </soulbinding>
+  </recipe>
+
+
+</enderio:recipes>

--- a/overrides/config/enderio/recipes/user/Vat.xml
+++ b/overrides/config/enderio/recipes/user/Vat.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<enderio:recipes xmlns:enderio="http://enderio.com/recipes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://enderio.com/recipes recipes.xsd ">
+
+
+<recipe name="Rocket Fuel"><disabled/></recipe>
+
+<recipe name="Ender Distilation"><disabled/></recipe>
+
+<recipe name="Ender Distilation Omni" required="true">
+    <fermenting energy="5000">
+      <inputgroup>
+        <input name="itemPulsatingPowder" multiplier="2.0"/>
+      </inputgroup>
+      <inputgroup>
+        <input name="itemVibrantPowder" multiplier="2.0"/>
+      </inputgroup>
+      <inputfluid name="ender" multiplier="0.5"/>
+      <outputfluid name="ender_distillation"/>
+    </fermenting>
+  </recipe>
+
+</enderio:recipes>

--- a/overrides/config/enderio/recipes/user/Vat.xml
+++ b/overrides/config/enderio/recipes/user/Vat.xml
@@ -7,7 +7,7 @@
 
 <recipe name="Ender Distilation"><disabled/></recipe>
 
-<recipe name="Ender Distilation Omni" required="true">
+<recipe name="Ender Distillation Omni" required="true">
     <fermenting energy="5000">
       <inputgroup>
         <input name="itemPulsatingPowder" multiplier="2.0"/>

--- a/overrides/scripts/EnderIO.zs
+++ b/overrides/scripts/EnderIO.zs
@@ -87,29 +87,6 @@ for item in teBalls {
     recipes.remove(item);
 }
 
-// Slice'n'Splice dead-ends
-mods.enderio.SliceNSplice.removeRecipe(<enderio:item_material:40>);       // Zombie Electrode
-mods.jei.JEI.removeAndHide(<enderio:item_material:40>);                   // Zombie Electrode
-
-mods.enderio.SliceNSplice.removeRecipe(<enderio:item_capacitor_totemic>); // Totemic Capacitor
-mods.jei.JEI.removeAndHide(<enderio:item_capacitor_totemic>);             // Totemic Capacitor
-
-
-// Restore Slice 'n' Splice recipes changed by updating Ender IO
-//Skeletal Contractor
-mods.enderio.SliceNSplice.removeRecipe(<enderio:item_material:45>); 
-mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:45>, [
-    <enderio:item_alloy_ingot:7>, <minecraft:skull>, <enderio:item_alloy_ingot:7>,
-     <minecraft:rotten_flesh> , <gregtech:meta_item_2:32440> , <minecraft:rotten_flesh>
-], 20000);
-
-//Guardian Diode
-mods.enderio.SliceNSplice.removeRecipe(<enderio:item_material:56>);
-mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:56>, [
-    <enderio:item_alloy_ingot:1>, <minecraft:prismarine_shard>, <enderio:item_alloy_ingot:1>,
-     <minecraft:prismarine_crystals>, <gregtech:meta_item_2:32440>, <minecraft:prismarine_crystals>
-], 20000);
-
 /*
 
   EnderIO Additions
@@ -245,30 +222,6 @@ for i, wafer in wafers {
     bonus = bonus * 2;
     cost  = cost  * 2;
 
-    // Z-Logic Controller
-    mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:41> * bonus, [
-        <enderio:item_alloy_ingot:7> , <minecraft:skull:2>  , <enderio:item_alloy_ingot:7>
-        , wafer                      , <minecraft:redstone> , wafer
-    ], cost);
-
-    // Ender Resonator
-    mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:43> * bonus, [
-        <enderio:item_alloy_ingot:7> , <enderio:block_enderman_skull> , <enderio:item_alloy_ingot:7>
-        , wafer                      , <enderio:item_alloy_ingot:2>   , wafer
-    ], cost);
-
-    // Skeletal Contractor
-    mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:45> * bonus, [
-        <enderio:item_alloy_ingot:7> , <minecraft:skull> , <enderio:item_alloy_ingot:7>
-        , <minecraft:rotten_flesh>   , wafer             , <minecraft:rotten_flesh>
-    ], cost);
-
-    // Guardian Diode
-    mods.enderio.SliceNSplice.addRecipe(<enderio:item_material:56> * bonus, [
-        <enderio:item_alloy_ingot:1>      , <minecraft:prismarine_shard> , <enderio:item_alloy_ingot:1>
-        , <minecraft:prismarine_crystals> , wafer                        , <minecraft:prismarine_crystals>
-    ], cost);
-
     // EnderIO Light
     makeShaped("enderio_light_" + bonus, <enderio:block_electric_light> * bonus, [
         "GGG",
@@ -377,95 +330,6 @@ furnace.addRecipe(<enderio:item_alloy_ingot:0>, <gregtech:meta_item_1:2705>);
 furnace.remove(<gregtech:meta_item_1:10704>, <gregtech:meta_item_1:2704>);
 furnace.addRecipe(<enderio:item_alloy_ingot:6>, <gregtech:meta_item_1:2704>);
 
-// Tokens
-
-val hostile = [
-    "minecraft:wither_skeleton",
-    "minecraft:stray",
-    "minecraft:husk",
-    "minecraft:zombie_villager",
-    "minecraft:evocation_illager",
-    "minecraft:zombie_horse",
-    "minecraft:vex",
-    "minecraft:vindication_illager",
-    "minecraft:illusion_illager",
-    "minecraft:creeper",
-    "minecraft:skeleton",
-    "minecraft:spider",
-    "minecraft:giant",
-    "minecraft:zombie",
-    "minecraft:slime",
-    "minecraft:ghast",
-    "minecraft:zombie_pigman",
-    "minecraft:enderman",
-    "minecraft:cave_spider",
-    "minecraft:silverfish",
-    "minecraft:blaze",
-    "minecraft:magma_cube",
-    "minecraft:witch",
-    "minecraft:endermite",
-    "minecraft:guardian",
-    "minecraft:shulker",
-    "thermalfoundation:blizz",
-    "thermalfoundation:blitz",
-    "thermalfoundation:basalz",
-    "draconicevolution:chaosguardian",
-    "deepmoblearning:glitch",
-    "deepmoblearning:trial_enderman",
-    "deepmoblearning:trial_spider",
-    "deepmoblearning:trial_cave_spider",
-    "deepmoblearning:trial_slime",
-    "armorplus:ender_dragon_zombie",  
-    "armorplus:ice_golem",
-    "armorplus:overlord_of_the_guardians",
-    "armorplus:skeletal_king",
-    "armorplus:witherling",
-    "armorplus:demonic_dragon",
-    "nuclearcraft:feral_ghoul"
-
-    ] as string[];
-
-val peaceful = [
-    "minecraft:donkey",
-    "minecraft:mule",
-    "minecraft:bat",
-    "minecraft:pig",
-    "minecraft:sheep",
-    "minecraft:cow",
-    "minecraft:chicken",
-    "minecraft:squid",
-    "minecraft:wolf",
-    "minecraft:mooshroom",
-    "minecraft:snowman",
-    "minecraft:ocelot",
-    "minecraft:villager_golem",
-    "minecraft:horse",
-    "minecraft:rabbit",
-    "minecraft:polar_bear",
-    "minecraft:llama",
-    "minecraft:parrot",
-    "minecraft:villager"
-
-] as string[];
-
-var combined as string[] = hostile;
-
-for mob in peaceful {
-    combined += mob;
-}
-
-//Monster Token
-mods.enderio.SoulBinder.removeRecipe(<enderio:item_material:79>);
-mods.enderio.SoulBinder.addRecipe(<enderio:item_material:79>, <darkutils:filter:3>, hostile, 25000, 1);
-
-//Animal Token
-mods.enderio.SoulBinder.removeRecipe(<enderio:item_material:78>);
-mods.enderio.SoulBinder.addRecipe(<enderio:item_material:78>, <darkutils:filter:4>, peaceful, 25000, 1);
-
-//Player Token
-mods.enderio.SoulBinder.removeRecipe(<enderio:item_material:80>);
-mods.enderio.SoulBinder.addRecipe(<enderio:item_material:80>, <darkutils:filter>, combined, 25000, 1);
-
 //Fixing Multismelter output of the dusts of the GTCE variants of Ender IO ingots
 val materialList as IItemStack[][] = [
     
@@ -493,6 +357,3 @@ for dust in materialList {
 recipes.addShapeless(<enderio:block_cap_bank:1>, [<enderio:block_cap_bank:1>]);
 recipes.addShapeless(<enderio:block_cap_bank:2>, [<enderio:block_cap_bank:2>]);
 recipes.addShapeless(<enderio:block_cap_bank:3>, [<enderio:block_cap_bank:3>]);
-
-//Temporary Fix for the Flight Control Unit Recipe
-mods.enderio.SoulBinder.addRecipe(<simplyjetpacks:metaitemmods:6>, <simplyjetpacks:metaitemmods:5>, ["minecraft:bat"], 75000, 8);

--- a/overrides/scripts/JetpacksAndEnergyStorage.zs
+++ b/overrides/scripts/JetpacksAndEnergyStorage.zs
@@ -406,8 +406,6 @@ recipes.addShaped(<enderio:block_franken_zombie_generator>, [
 	[<ore:skullZombieFrankenstein>, <enderio:block_zombie_generator>, <ore:skullZombieFrankenstein>],
 	[<gregtech:meta_item_2:26705>, <ore:ingotSoularium>, <gregtech:meta_item_2:26705>]]);
 
-mods.enderio.Vat.removeRecipe(<liquid:rocket_fuel>);
-
 //The Vat
 recipes.remove(<enderio:block_vat>);
 recipes.addShaped(<enderio:block_vat>, [

--- a/overrides/scripts/Midgame.zs
+++ b/overrides/scripts/Midgame.zs
@@ -249,13 +249,6 @@ recipes.addShaped(<metaitem:component.capacitor> * 4, [
 	[<gregtech:meta_item_1:19189>, <gregtech:meta_item_1:12152>, <gregtech:meta_item_1:19189>], 
 	[<gregtech:meta_item_2:16062>, null, <gregtech:meta_item_2:16062>]]);
 
-//Dew Of The Void
-mods.enderio.Vat.removeRecipe(<liquid:ender_distillation> * 1000);
-mods.enderio.Vat.addRecipe(<liquid:ender_distillation> * 1000, 0.5, <liquid:ender> * 4000, [<enderio:item_material:36>], [2], [<enderio:item_material:35>], [2]);
-
-//Ghast for Flight Controller
-mods.enderio.SoulBinder.addRecipe(<simplyjetpacks:metaitemmods:6>, <simplyjetpacks:metaitemmods:5>, ["ghast"], 75000, 300);
-
 assembler.recipeBuilder().inputs([<simplyjetpacks:metaitemmods:18>]).fluidInputs([<liquid:glowstone> * 4320]).outputs([<simplyjetpacks:metaitemmods:19>]).duration(2000).EUt(3000).buildAndRegister();
 assembler.recipeBuilder().inputs([<simplyjetpacks:metaitemmods:20>]).fluidInputs([<liquid:cryotheum> * 4320]).outputs([<simplyjetpacks:metaitemmods:21>]).duration(2000).EUt(8000).buildAndRegister();
 

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -1633,6 +1633,8 @@ mods.jei.JEI.removeAndHide(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio
 mods.jei.JEI.removeAndHide(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiointegrationforestry:apiarist_armor_legs"}));
 mods.jei.JEI.removeAndHide(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiointegrationforestry:naturalist_eye"}));
 mods.jei.JEI.removeAndHide(<enderio:item_dark_steel_upgrade:1>.withTag({"enderio:dsu": "enderiointegrationforestry:apiarist_armor_feet"}));
+mods.jei.JEI.removeAndHide(<enderio:item_capacitor_totemic>);
+mods.jei.JEI.removeAndHide(<enderio:item_material:40>);  
 
 
 //Extended Crafting Removals


### PR DESCRIPTION
Removes EnderTweaker because it is abandoned and not compatible with the latest versions of Ender IO.

Transitions our recipe additions that were done with EnderTweaker to Ender IO's XML recipe system.