### PR TITLE
Update More Furnaces, Drop CXLibrary

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -82,11 +82,6 @@
       "required": true
     },
     {
-      "projectID": 244023,
-      "fileID": 2463886,
-      "required": true
-    },
-    {
       "projectID": 243478,
       "fileID": 2745657,
       "required": true
@@ -413,7 +408,7 @@
     },
     {
       "projectID": 391401,
-      "fileID": 3049346,
+      "fileID": 3418767,
       "required": true
     },
     {


### PR DESCRIPTION
Updates the Omnifactory fork of More Furnaces.

Removes the library mod CXLibrary as More Furnaces no longer requires it.