### PR TITLE
Remove Osmium Smelting

### DIFF
--- a/overrides/config/enderio/recipes/user/user_recipes.xml
+++ b/overrides/config/enderio/recipes/user/user_recipes.xml
@@ -9,4 +9,7 @@
 <recipe name="Gear, Stone" disabled="true" />
 <recipe name="Gear, Stone, Upgrade" disabled="true" />
 
+
+ <recipe name="Smelting: Osmium Dust" disabled="true"/>
+
 </enderio:recipes>

--- a/overrides/scripts/BlastFurnace.zs
+++ b/overrides/scripts/BlastFurnace.zs
@@ -15,6 +15,7 @@ furnace.remove(<appliedenergistics2:material:5>);
 furnace.remove(<thermalfoundation:material:167>, <gregtech:meta_item_1:2708>);
 furnace.remove(<thermalfoundation:material:166>, <gregtech:meta_item_1:2706>);
 furnace.remove(<thermalfoundation:material:165>, <gregtech:meta_item_1:2707>);
+furnace.remove(<ore:ingotOsmium>);
 
 //  Tier 0										Steel, Silicon
 //	Tier 1	[1000 temp]		120		Copper		Black Steel, Annealed Copper
@@ -193,6 +194,16 @@ blast_furnace.findRecipe(480, [<gregtech:meta_item_1:10045>,<gregtech:meta_item_
 blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2135>], [null]).remove();	
 furnace.addRecipe(<gregtech:meta_item_1:10135>, <gregtech:meta_item_1:2135>, 0.0);
 blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:10045>,<gregtech:meta_item_1:10072>]).outputs([<gregtech:meta_item_1:11135> * 2]).property("temperature", 4500).duration(7000).EUt(120).buildAndRegister();	
+
+//Osmium [Tier 10]
+
+blast_furnace.findRecipe(120, [<metaitem:dustOsmium>], [null]).remove();
+
+blast_furnace.recipeBuilder()
+	.inputs(<metaitem:dustOsmium>)
+	.outputs(<metaitem:ingotHotOsmium>)
+	.property("temperature", 3306)
+	.duration(400).EUt(120).buildAndRegister();
 
 //Naquadah [tier 11]
 blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2307>], [null]).remove();	

--- a/overrides/scripts/BlastFurnace.zs
+++ b/overrides/scripts/BlastFurnace.zs
@@ -15,7 +15,6 @@ furnace.remove(<appliedenergistics2:material:5>);
 furnace.remove(<thermalfoundation:material:167>, <gregtech:meta_item_1:2708>);
 furnace.remove(<thermalfoundation:material:166>, <gregtech:meta_item_1:2706>);
 furnace.remove(<thermalfoundation:material:165>, <gregtech:meta_item_1:2707>);
-furnace.remove(<ore:ingotOsmium>);
 
 //  Tier 0										Steel, Silicon
 //	Tier 1	[1000 temp]		120		Copper		Black Steel, Annealed Copper


### PR DESCRIPTION
Removes Osmium dust smelting into ingots in the Furnace.

To compensate, lowers the duration of the EBF recipe by a lot (628 seconds -> 20 seconds)

This is similar to the change that was done for the Naquadah Ingot, where the furnace recipe was removed and a fast EBF recipe was added in 144c273

Closes #463 