### PR TITLE
Add microverse mission for glitch hearts

### DIFF
--- a/overrides/scripts/Multiblocks.zs
+++ b/overrides/scripts/Multiblocks.zs
@@ -879,9 +879,9 @@ val naquadahreactormk1 = Builder.start(loc, id)
                         .build())
     .buildAndRegister() as Multiblock;
 
-id += 1;
+id += 1; 
 loc = "naquadahreactormk2";
-
+ 
 val naquadahreactormk2 = Builder.start(loc,id)
     .withPattern(
         FactoryBlockPattern.start(RelativeDirection.RIGHT, RelativeDirection.BACK, RelativeDirection.UP)
@@ -1209,7 +1209,7 @@ for meta in 0 .. 7 {
         <ore:ingotMicroversium>.firstItem * count,
         [itemUtils.getItem("modularmachinery:blockinputbus", meta)]);
 
-    recipes.addShapeless("mm_outputbus_conversion__" ~ meta,
+    recipes.addShapeless("mm_outputbus_conversion__" ~ meta, 
         <ore:ingotMicroversium>.firstItem * count,
         [itemUtils.getItem("modularmachinery:blockoutputbus", meta)]);
 }
@@ -1218,12 +1218,12 @@ for meta in 0 .. 7 {
 for meta in 0 .. 8 {
     // tiny returns 4 from the casing, then there's 3 more ingots per tier
     val count as int = (4 + meta * 3);
-
+    
     recipes.addShapeless("mm_fluidinput_refund_" ~ meta,
         <ore:ingotMicroversium>.firstItem * count,
         [itemUtils.getItem("modularmachinery:blockfluidinputhatch", meta)]);
 
-    recipes.addShapeless("mm_fluidoutput_refund_" ~ meta,
+    recipes.addShapeless("mm_fluidoutput_refund_" ~ meta, 
         <ore:ingotMicroversium>.firstItem * count,
         [itemUtils.getItem("modularmachinery:blockfluidoutputhatch", meta)]);
 }
@@ -1361,7 +1361,7 @@ makeShaped("lunar_mining_station", <gregtech:machine:3007>,
      "CLC"],
     { C : <ore:circuitExtreme>, //T4
       L : <gregtech:machine_casing:6>, //LuV Machine Casing
-      S : <extrautils2:screen>});
+      S : <extrautils2:screen>}); 
 
 ///////////////////////////////////////////////
 ////////////  Multiblock Recipes  /////////////

--- a/overrides/scripts/Multiblocks.zs
+++ b/overrides/scripts/Multiblocks.zs
@@ -1428,7 +1428,7 @@ small_microverse.recipeMap
     .EUt(500)
     .inputs(<contenttweaker:tieroneship>,
             <deepmoblearning:trial_key>,
-						<deepmoblearning:pristine_matter_zombie>)
+            <deepmoblearning:pristine_matter_zombie>)
     .fluidInputs(<liquid:rocket_fuel> * 2000)
     .outputs(<deepmoblearning:glitch_heart>)
     .buildAndRegister();

--- a/overrides/scripts/Multiblocks.zs
+++ b/overrides/scripts/Multiblocks.zs
@@ -879,9 +879,9 @@ val naquadahreactormk1 = Builder.start(loc, id)
                         .build())
     .buildAndRegister() as Multiblock;
 
-id += 1; 
+id += 1;
 loc = "naquadahreactormk2";
- 
+
 val naquadahreactormk2 = Builder.start(loc,id)
     .withPattern(
         FactoryBlockPattern.start(RelativeDirection.RIGHT, RelativeDirection.BACK, RelativeDirection.UP)
@@ -1209,7 +1209,7 @@ for meta in 0 .. 7 {
         <ore:ingotMicroversium>.firstItem * count,
         [itemUtils.getItem("modularmachinery:blockinputbus", meta)]);
 
-    recipes.addShapeless("mm_outputbus_conversion__" ~ meta, 
+    recipes.addShapeless("mm_outputbus_conversion__" ~ meta,
         <ore:ingotMicroversium>.firstItem * count,
         [itemUtils.getItem("modularmachinery:blockoutputbus", meta)]);
 }
@@ -1218,12 +1218,12 @@ for meta in 0 .. 7 {
 for meta in 0 .. 8 {
     // tiny returns 4 from the casing, then there's 3 more ingots per tier
     val count as int = (4 + meta * 3);
-    
+
     recipes.addShapeless("mm_fluidinput_refund_" ~ meta,
         <ore:ingotMicroversium>.firstItem * count,
         [itemUtils.getItem("modularmachinery:blockfluidinputhatch", meta)]);
 
-    recipes.addShapeless("mm_fluidoutput_refund_" ~ meta, 
+    recipes.addShapeless("mm_fluidoutput_refund_" ~ meta,
         <ore:ingotMicroversium>.firstItem * count,
         [itemUtils.getItem("modularmachinery:blockfluidoutputhatch", meta)]);
 }
@@ -1361,7 +1361,7 @@ makeShaped("lunar_mining_station", <gregtech:machine:3007>,
      "CLC"],
     { C : <ore:circuitExtreme>, //T4
       L : <gregtech:machine_casing:6>, //LuV Machine Casing
-      S : <extrautils2:screen>}); 
+      S : <extrautils2:screen>});
 
 ///////////////////////////////////////////////
 ////////////  Multiblock Recipes  /////////////
@@ -1419,6 +1419,18 @@ small_microverse.recipeMap
             <contenttweaker:ultradensehydrogen>)
     .fluidInputs(<liquid:rocket_fuel> * 2000)
     .outputs(<contenttweaker:stellarcreationdata>)
+    .buildAndRegister();
+
+// Tier 1 Steel Microminer: Mission 4 - Glitch Heart
+small_microverse.recipeMap
+    .recipeBuilder()
+    .duration(100)
+    .EUt(500)
+    .inputs(<contenttweaker:tieroneship>,
+            <deepmoblearning:trial_key>,
+						<deepmoblearning:pristine_matter_zombie>)
+    .fluidInputs(<liquid:rocket_fuel> * 2000)
+    .outputs(<deepmoblearning:glitch_heart>)
     .buildAndRegister();
 
 // Tier 2 Titanium Microminer - Mission 1: Radium and Early/Midgame Ores


### PR DESCRIPTION
This pull request adds a tier one microverse mission which consumes a tier one microminer, a trial key and a pristine zombie matter and produces a glitch heart. 

I noticed that when playing in peaceful mode it's surprisingly hard to get flight. The glitch armor is unobtainable so it seems the earliest option for flight is the dragon armor. Adding this microverse mission allows players playing in peaceful mode to get flight a fair amount earlier (though still latter than non-peaceful players). Later microverse mission replace killing the ender dragon and chaos guardian so I think the it makes sense for an early microverse mission to be able to replace dml trials. 