### PR TITLE
Changing the default rate (and folder size) of backups.

### DIFF
--- a/overrides/config/ftbbackups.cfg
+++ b/overrides/config/ftbbackups.cfg
@@ -14,7 +14,7 @@ general {
     # 0 - Infinite
     # Min: 0
     # Max: 32000
-    I:backups_to_keep=6
+    I:backups_to_keep=12
 
     # Buffer size for writing files Don't change unless you know what you are doing.
     # Min: 256

--- a/overrides/config/ftbbackups.cfg
+++ b/overrides/config/ftbbackups.cfg
@@ -51,7 +51,7 @@ general {
     # You can use TB, GB, MB and KB for filesizes.
     # You can use % to set maximum total size based on your available disk space. It is still limited by max total backup count, so it's not gonna fill up large drives.
     # Valid inputs: 50 GB, 10 MB, 33%
-    S:max_total_size=50 GB
+    S:max_total_size=2 GB
 
     # Only create backups when players have been online.
     B:only_if_players_online=true

--- a/overrides/config/ftbbackups.cfg
+++ b/overrides/config/ftbbackups.cfg
@@ -7,14 +7,14 @@ general {
     # 0.5 - backups every 30 minutes
     # Min: 0.05
     # Max: 600.0
-    D:backup_timer=2.0
+    D:backup_timer=0.5
 
     # The number of backup files to keep.
     # More backups = more space used
     # 0 - Infinite
     # Min: 0
     # Max: 32000
-    I:backups_to_keep=12
+    I:backups_to_keep=6
 
     # Buffer size for writing files Don't change unless you know what you are doing.
     # Min: 256

--- a/overrides/config/ftbbackups.cfg
+++ b/overrides/config/ftbbackups.cfg
@@ -51,7 +51,7 @@ general {
     # You can use TB, GB, MB and KB for filesizes.
     # You can use % to set maximum total size based on your available disk space. It is still limited by max total backup count, so it's not gonna fill up large drives.
     # Valid inputs: 50 GB, 10 MB, 33%
-    S:max_total_size=2 GB
+    S:max_total_size=1 GB
 
     # Only create backups when players have been online.
     B:only_if_players_online=true


### PR DESCRIPTION
Reduced the time between backups from 2 hours to 30 minutes.

Breadchild from the discord explains it well

"What is really really important though is the backup frequency, 2 hours is ridiculous for singleplayer. Everytime you exit the world this timer resets as well, so if your play sessions never exceed 2 hours, you never get a backup. Not to mention losing 2 hours of progress would suck even if it was done correctly"