### PR TITLE
Fix #820 (tiny/small black steel dust recipe)

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -277,6 +277,8 @@ mixer.recipeBuilder().inputs([<gregtech:meta_item_1:2307>,<enderio:item_material
 mixer.recipeBuilder().inputs([<gregtech:meta_item_1:2308>,<enderio:item_material:34>,<enderio:item_material:35>*4,<enderio:item_material:37>]).fluidInputs([<liquid:enderium> * 576, <liquid:curium> * 144]).outputs(<gregtech:meta_item_1:2310>).EUt(30000).duration(400).buildAndRegister();
 mixer.recipeBuilder().inputs([<ore:dustSteel> * 3,<ore:dustBlackBronze> * 2,<actuallyadditions:item_crystal:3> * 2,<extrautils2:ingredients:4> * 2]).outputs(<gregtech:meta_item_1:2231>  * 9).EUt(15).duration(200).buildAndRegister();
 recipes.remove(<gregtech:meta_item_1:2231>);
+recipes.remove(<gregtech:meta_item_1:231>);
+recipes.remove(<gregtech:meta_item_1:1231>);
 furnace.addRecipe(<actuallyadditions:item_misc:5>, <actuallyadditions:block_misc:3>, 0.0);
 
 reactor.recipeBuilder().inputs([<minecraft:quartz>]).fluidInputs([<liquid:glowstone> * 288]).outputs(<thermalfoundation:material:894>).EUt(100).duration(100).buildAndRegister();


### PR DESCRIPTION
Removes the GTCE recipes for tiny and small piles of Black Steel Dust, which are easier than the intended one.
first commit to main omnifactory if this gets approved lol