### PR TITLE
Address confirmed Log4J security vulnerability for Minecraft Servers

### DIFF
--- a/launchscripts/launch.bat
+++ b/launchscripts/launch.bat
@@ -16,7 +16,7 @@ SET MIN_RAM={{minRAM}}
 SET MAX_RAM={{maxRAM}}
 
 :: DO NOT EDIT ANYTHING PAST THIS LINE
-SET LAUNCHPARAMS=-server -Xms%MIN_RAM% -Xmx%MAX_RAM% %JAVA_PARAMETERS% -jar %FORGEJAR% nogui
+SET LAUNCHPARAMS=-server -Xms%MIN_RAM% -Xmx%MAX_RAM% %JAVA_PARAMETERS% -Dlog4j.configurationFile=log4j2_112-116.xml -jar %FORGEJAR% nogui
 echo Checking java version...
 echo.
 java -version

--- a/launchscripts/launch.sh
+++ b/launchscripts/launch.sh
@@ -17,7 +17,7 @@ MIN_RAM='{{minRAM}}'
 MAX_RAM='{{maxRAM}}'
 
 # DO NOT EDIT ANYTHING PAST THIS LINE
-LAUNCHPARAMS="-server -Xms$MIN_RAM -Xmx$MAX_RAM $JAVA_PARAMETERS -jar $FORGEJAR nogui"
+LAUNCHPARAMS="-server -Xms$MIN_RAM -Xmx$MAX_RAM $JAVA_PARAMETERS -Dlog4j.configurationFile=log4j2_112-116.xml -jar $FORGEJAR nogui"
 
 echo "Checking java version..."
 echo

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "version": "1.12.2",
     "modLoaders": [
       {
-        "id": "forge-14.23.5.2858",
+        "id": "forge-14.23.5.2860",
         "primary": true
       }
     ]

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "version": "1.12.2",
     "modLoaders": [
       {
-        "id": "forge-14.23.5.2855",
+        "id": "forge-14.23.5.2858",
         "primary": true
       }
     ]

--- a/serverfiles/log4j2_112-116.xml
+++ b/serverfiles/log4j2_112-116.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="SysOut" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg{nolookups}%n" />
+        </Console>
+        <Queue name="ServerGuiConsole">
+            <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg{nolookups}%n" />
+        </Queue>
+        <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
+            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg{nolookups}%n" />
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+                <OnStartupTriggeringPolicy />
+            </Policies>
+        </RollingRandomAccessFile>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <filters>
+                <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL" />
+            </filters>
+            <AppenderRef ref="SysOut"/>
+            <AppenderRef ref="File"/>
+            <AppenderRef ref="ServerGuiConsole"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Per the security vulnerability disclosure reported today at https://www.minecraft.net/en-us/article/important-message--security-vulnerability-java-edition, take the following remedial steps to patch it by default in the Omnifactory server zip:

1. add the XML configuration file to be placed in servers as part of the build process, and
2. add the JVM argument to both of our launch scripts.