### PR TITLE
Enable miscellaneous AE2 tools

### DIFF
--- a/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -122,18 +122,18 @@ features {
 
     tools {
         B:ChargedStaff=false
-        B:ColorApplicator=false
-        B:EntropyManipulator=false
+        B:ColorApplicator=true
+        B:EntropyManipulator=true
         B:MatterCannon=false
         B:MeteoriteCompass=true
-        B:PaintBalls=false
+        B:PaintBalls=true
         B:QuartzAxe=false
         B:QuartzHoe=false
-        B:QuartzKnife=false
+        B:QuartzKnife=true
         B:QuartzPickaxe=false
         B:QuartzSpade=false
         B:QuartzSword=false
-        B:QuartzWrench=false
+        B:QuartzWrench=true
         B:WirelessAccessTerminal=true
     }
 
@@ -452,5 +452,3 @@ worldgen {
     I:quartzOresPerCluster=4
     D:spawnChargedChance=0.07999998331069946
 }
-
-


### PR DESCRIPTION
Re-enables miscellaneous AE2 tools, including the quartz knife mentioned #793. If players want to rename items and blocks automatically, let them.

Certified quality-of-life-only addition.

List of re-enabled tools:
* Color Applicator
* Entropy Manipulator
* Paint Balls
* Quartz Knife
* Quartz Wrench
