### PR TITLE
JEI QoL pass for Gregtech ore

### DIFF
--- a/overrides/config/gregtech/dimensions.json
+++ b/overrides/config/gregtech/dimensions.json
@@ -19,6 +19,30 @@
     {
       "dimID": 100,
       "dimName": "Moon"
+    },
+    {
+      "dimID": 101,
+      "dimName": "Mercury"
+    },
+    {
+      "dimID": 102,
+      "dimName": "Venus"
+    },
+    {
+      "dimID": 103,
+      "dimName": "Mars"
+    },
+    {
+      "dimID": 105,
+      "dimName": "Io"
+    },
+    {
+      "dimID": 106,
+      "dimName": "Europa"
+    },
+    {
+      "dimID": 108,
+      "dimName": "Titan"
     }
   ]
 }

--- a/overrides/config/gregtech/worldgen/moon/aluminium_vein.json
+++ b/overrides/config/gregtech/worldgen/moon/aluminium_vein.json
@@ -1,8 +1,9 @@
 {
-  "weight": 0,
+  "weight": 50,
   "density": 0.6,
   "max_height": 90,
   "min_height": 40,
+  "dimension_filter": ["name:planet"],
     "biome_modifier": {
 		"type": "biome_map",
 		"advancedrocketry:moon": 80,

--- a/overrides/config/gregtech/worldgen/moon/diamond_vein.json
+++ b/overrides/config/gregtech/worldgen/moon/diamond_vein.json
@@ -1,8 +1,9 @@
 {
-  "weight": 0,
+  "weight": 50,
   "density": 0.6,
   "max_height": 40,
   "min_height": 5,
+  "dimension_filter": ["name:planet"],
       "biome_modifier": {
 		"type": "biome_map",
 		"advancedrocketry:moon": 60,

--- a/overrides/config/gregtech/worldgen/moon/gold_vein.json
+++ b/overrides/config/gregtech/worldgen/moon/gold_vein.json
@@ -1,8 +1,9 @@
 {
-  "weight": 0,
+  "weight": 50,
   "density": 0.5,
   "max_height": 120,
   "min_height": 50,
+  "dimension_filter": ["name:planet"],
       "biome_modifier": {
 		"type": "biome_map",
 		"advancedrocketry:moon": 40,

--- a/overrides/config/gregtech/worldgen/moon/manganese_vein.json
+++ b/overrides/config/gregtech/worldgen/moon/manganese_vein.json
@@ -1,8 +1,9 @@
 {
-  "weight": 0,
+  "weight": 50,
   "density": 0.5,
   "max_height": 50,
   "min_height": 20,
+  "dimension_filter": ["name:planet"],
       "biome_modifier": {
 		"type": "biome_map",
 		"advancedrocketry:moon": 30,

--- a/overrides/config/gregtech/worldgen/moon/quartz_vein.json
+++ b/overrides/config/gregtech/worldgen/moon/quartz_vein.json
@@ -1,8 +1,9 @@
 {
-  "weight": 0,
+  "weight": 50,
   "density": 0.6,
   "max_height": 80,
   "min_height": 40,
+  "dimension_filter": ["name:planet"],
       "biome_modifier": {
 		"type": "biome_map",
 		"advancedrocketry:moon": 40,

--- a/overrides/config/gregtech/worldgen/moon/rutile_vein.json
+++ b/overrides/config/gregtech/worldgen/moon/rutile_vein.json
@@ -1,8 +1,9 @@
 {
-  "weight": 0,
+  "weight": 50,
   "density": 0.6,
   "max_height": 45,
   "min_height": 10,
+  "dimension_filter": ["name:planet"],
       "biome_modifier": {
 		"type": "biome_map",
 		"advancedrocketry:moon": 80,

--- a/overrides/config/gregtech/worldgen/moon/tungsten_vein.json
+++ b/overrides/config/gregtech/worldgen/moon/tungsten_vein.json
@@ -1,8 +1,9 @@
 {
-  "weight": 0,
+  "weight": 50,
   "density": 0.5,
   "max_height": 50,
   "min_height": 20,
+  "dimension_filter": ["name:planet"],
       "biome_modifier": {
 		"type": "biome_map",
 		"advancedrocketry:moon": 70,

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -442,10 +442,11 @@ recipes.addShaped(<gregtech:machine:210>, [
 
 furnace.addRecipe(<gregtech:meta_item_1:2063>, <gregtech:meta_item_1:2155>, 0.0);
 furnace.addRecipe(<ore:ingotCopper>.firstItem,<ore:oreCopper>);
-furnace.addRecipe(<ore:ingotCopper>.firstItem,<gregtech:ore_copper_0:0>);
-furnace.addRecipe(<ore:ingotCopper>.firstItem,<gregtech:ore_copper_0:1>);
-furnace.addRecipe(<ore:ingotCopper>.firstItem,<gregtech:ore_copper_0:2>);
-furnace.addRecipe(<ore:ingotCopper>.firstItem,<gregtech:ore_copper_0:3>);
+// these appear to be a no-op
+// furnace.addRecipe(<ore:ingotCopper>.firstItem,<gregtech:ore_copper_0:0>);
+// furnace.addRecipe(<ore:ingotCopper>.firstItem,<gregtech:ore_copper_0:1>);
+// furnace.addRecipe(<ore:ingotCopper>.firstItem,<gregtech:ore_copper_0:2>);
+// furnace.addRecipe(<ore:ingotCopper>.firstItem,<gregtech:ore_copper_0:3>);
 furnace.addRecipe(<gregtech:meta_item_1:10018>, <gregtech:meta_item_1:2100>, 0.0);
 
 furnace.remove(<minecraft:iron_nugget> * 3, <gregtech:meta_item_1:3148>);

--- a/overrides/scripts/Multiblocks.zs
+++ b/overrides/scripts/Multiblocks.zs
@@ -1379,12 +1379,12 @@ small_microverse.recipeMap
             <minecraft:chest>)
     .fluidInputs(<liquid:rocket_fuel> * 8000)
     .outputs(<densemetals:dense_iron_ore> * 64,
-             <gregtech:ore_cassiterite_0:3> * 64,
+             <gregtech:ore_cassiterite_0> * 64,
              <gregtech:ore_redstone_0> * 64,
              <gregtech:ore_nickel_0> * 64,
              <gregtech:ore_rutile_0> * 64,
              <gregtech:ore_rutile_0> * 64,
-             <gregtech:ore_uraninite_0:3> * 64,
+             <gregtech:ore_uraninite_0> * 64,
              <gregtech:ore_galena_0> * 64,
              <gregtech:ore_galena_0> * 64,
              <advancedrocketry:moonturf> * 64,
@@ -1429,21 +1429,21 @@ small_microverse.recipeMap
     .inputs(<contenttweaker:tiertwoship>,
             <contenttweaker:quantumflux> * 2)
     .fluidInputs(<liquid:rocket_fuel> * 12000)
-    .outputs(<gregtech:ore_bauxite_0:1> * 64,
-             <gregtech:ore_bauxite_0:1> * 64,
-             <gregtech:ore_niobium_0:1> * 64,
-             <gregtech:ore_copper_0:1> * 64,
-             <gregtech:ore_sphalerite_0:1> * 64,
-             <gregtech:ore_sphalerite_0:1> * 64,
-             <gregtech:ore_scheelite_0:1> * 64,
-             <gregtech:ore_scheelite_0:1> * 64,
-             <gregtech:ore_scheelite_0:1> * 64,
-             <gregtech:ore_tungstate_0:1> * 64,
-             <gregtech:ore_tungstate_0:1> * 64,
-             <gregtech:ore_tungstate_0:1> * 64,
+    .outputs(<gregtech:ore_bauxite_0> * 64,
+             <gregtech:ore_bauxite_0> * 64,
+             <gregtech:ore_niobium_0> * 64,
+             <gregtech:ore_copper_0> * 64,
+             <gregtech:ore_sphalerite_0> * 64,
+             <gregtech:ore_sphalerite_0> * 64,
+             <gregtech:ore_scheelite_0> * 64,
+             <gregtech:ore_scheelite_0> * 64,
+             <gregtech:ore_scheelite_0> * 64,
+             <gregtech:ore_tungstate_0> * 64,
+             <gregtech:ore_tungstate_0> * 64,
+             <gregtech:ore_tungstate_0> * 64,
              <contenttweaker:radiumsalt> * 64,
              <contenttweaker:radiumsalt> * 64,
-             <gregtech:ore_cassiterite_0:1> * 64)
+             <gregtech:ore_cassiterite_0> * 64)
     .buildAndRegister();
 
 // Tier 2 Titanium Micro Miner - Mission 2: Stellar Creation Data
@@ -1478,9 +1478,9 @@ small_microverse.recipeMap
              <gregtech:meta_item_2:25154> * 16,
              <gregtech:meta_item_2:25154> * 16,
              <gregtech:meta_item_2:25154> * 16,
-             <gregtech:ore_sapphire_0:6> * 64,
-             <gregtech:ore_gold_0:6> * 64,
-             <gregtech:ore_silver_0:6> * 64)
+             <gregtech:ore_sapphire_0> * 64,
+             <gregtech:ore_gold_0> * 64,
+             <gregtech:ore_silver_0> * 64)
     .buildAndRegister();
 
 // Tier 3: Tungsten Carbide Micro Miner - Mission 2: Midgame Ores
@@ -1492,20 +1492,20 @@ small_microverse.recipeMap
             <contenttweaker:quantumflux> * 4,
             <gregtech:machine:1010>)
     .fluidInputs(<liquid:rocket_fuel> * 20000)
-    .outputs(<gregtech:ore_scheelite_0:6> * 64,
-             <gregtech:ore_scheelite_0:6> * 64,
-             <gregtech:ore_scheelite_0:6> * 64,
-             <gregtech:ore_tungstate_0:6> * 64,
-             <gregtech:ore_tungstate_0:6> * 64,
-             <gregtech:ore_tungstate_0:6> * 64,
-             <gregtech:ore_rutile_0:6> * 64,
-             <gregtech:ore_vanadium_magnetite_0:6> * 64,
-             <gregtech:ore_tetrahedrite_0:6> * 64,
-             <gregtech:ore_cassiterite_0:6> * 64,
-             <gregtech:ore_tin_0:6> * 64,
-             <gregtech:ore_redstone_0:6> * 64,
-             <gregtech:ore_certus_quartz_0:6> * 64,
-             <gregtech:ore_almandine_0:6> * 64)
+    .outputs(<gregtech:ore_scheelite_0> * 64,
+             <gregtech:ore_scheelite_0> * 64,
+             <gregtech:ore_scheelite_0> * 64,
+             <gregtech:ore_tungstate_0> * 64,
+             <gregtech:ore_tungstate_0> * 64,
+             <gregtech:ore_tungstate_0> * 64,
+             <gregtech:ore_rutile_0> * 64,
+             <gregtech:ore_vanadium_magnetite_0> * 64,
+             <gregtech:ore_tetrahedrite_0> * 64,
+             <gregtech:ore_cassiterite_0> * 64,
+             <gregtech:ore_tin_0> * 64,
+             <gregtech:ore_redstone_0> * 64,
+             <gregtech:ore_certus_quartz_0> * 64,
+             <gregtech:ore_almandine_0> * 64)
     .buildAndRegister();
 
 // Medium Microverse Projector
@@ -1563,18 +1563,18 @@ medium_microverse.recipeMap
     .inputs(<contenttweaker:tierfiveship>,
             <contenttweaker:quantumflux> * 16,
             <contenttweaker:stabilizeduranium> * 32)
-    .outputs(<gregtech:ore_uranium_0:12> * 64,
-             <gregtech:ore_palladium_0:12> * 64,
-             <gregtech:ore_tennantite_0:12> * 64,
-             <gregtech:ore_bastnasite_0:12> * 64,
-             <gregtech:ore_sphalerite_0:12> * 64,
-             <gregtech:ore_monazite_0:12> * 64,
+    .outputs(<gregtech:ore_uranium_0> * 64,
+             <gregtech:ore_palladium_0> * 64,
+             <gregtech:ore_tennantite_0> * 64,
+             <gregtech:ore_bastnasite_0> * 64,
+             <gregtech:ore_sphalerite_0> * 64,
+             <gregtech:ore_monazite_0> * 64,
              <gregtech:meta_block_compressed_13:10> * 64, //Ender Pearl Block
-             <gregtech:ore_osmium_0:12> * 16,
+             <gregtech:ore_osmium_0> * 16,
              <gregtech:meta_item_1:2009> * 64,
-             <gregtech:ore_molybdenite_0:12> * 64,
-             <gregtech:ore_beryllium_0:12> * 64,
-             <gregtech:ore_beryllium_0:12> * 64)
+             <gregtech:ore_molybdenite_0> * 64,
+             <gregtech:ore_beryllium_0> * 64,
+             <gregtech:ore_beryllium_0> * 64)
     .buildAndRegister();
 
 // Tier 5: Iridium Micro Miner - Mission 2: Naquadah
@@ -1600,15 +1600,15 @@ medium_microverse.recipeMap
             <contenttweaker:quantumflux> * 16,
             <contenttweaker:stabilizeduranium> * 32,
             <contenttweaker:witherrealmdata> * 16)
-    .outputs(<gregtech:ore_uranium_0:10> * 64,
-             <gregtech:ore_uranium_0:10> * 64,
-             <gregtech:ore_uranium_0:10> * 64,
-             <gregtech:ore_uranium_0:10> * 64,
-             <gregtech:ore_osmium_0:10> * 64,
-             <gregtech:ore_osmium_0:10> * 64,
-             <gregtech:ore_osmium_0:10> * 64,
-             <gregtech:ore_iridium_0:10> * 64,
-             <gregtech:ore_iridium_0:10> * 64)
+    .outputs(<gregtech:ore_uranium_0> * 64,
+             <gregtech:ore_uranium_0> * 64,
+             <gregtech:ore_uranium_0> * 64,
+             <gregtech:ore_uranium_0> * 64,
+             <gregtech:ore_osmium_0> * 64,
+             <gregtech:ore_osmium_0> * 64,
+             <gregtech:ore_osmium_0> * 64,
+             <gregtech:ore_iridium_0> * 64,
+             <gregtech:ore_iridium_0> * 64)
     .buildAndRegister();
 
 // Tier 6: Enderium Micro Miner - Mission 2: Stabilized Einsteinium

--- a/overrides/scripts/OreProcessing/DenseOres.zs
+++ b/overrides/scripts/OreProcessing/DenseOres.zs
@@ -22,7 +22,7 @@ val denseOres as IItemStack[][IOreDictEntry] = {
 	, <ore:denseOreLapis>    : [ <densemetals:dense_lapis_ore>    , <gregtech:ore_lapis_0>      ]
 	, <ore:denseOreGold>     : [ <densemetals:dense_gold_ore>     , <gregtech:ore_gold_0>       ]
 	, <ore:denseOreCoal>     : [ <densemetals:dense_coal_ore>     , <gregtech:ore_coal_0>       ]
-	, <ore:denseOreOilsands> : [ <contenttweaker:denseoilshale>   , <gregtech:ore_oilsands_0:2> ]
+	, <ore:denseOreOilsands> : [ <contenttweaker:denseoilshale>   , <gregtech:ore_oilsands_0>   ]
 };
 
 val fluidCatalyst = <liquid:nitric_acid> * 1000;

--- a/overrides/scripts/hideOres.zs
+++ b/overrides/scripts/hideOres.zs
@@ -1,0 +1,140 @@
+import crafttweaker.item.IItemDefinition;
+
+val gtOre		= [
+// obtainable via oregen
+    <gregtech:ore_almandine_0>				.definition,
+    <gregtech:ore_aluminium_0>				.definition,
+    <gregtech:ore_apatite_0>				.definition,
+    <gregtech:ore_banded_iron_0>			.definition,
+    <gregtech:ore_barite_0>				.definition,
+    <gregtech:ore_bastnasite_0>				.definition,
+    <gregtech:ore_bauxite_0>				.definition,
+    <gregtech:ore_bentonite_0>				.definition,
+    <gregtech:ore_beryllium_0>				.definition,
+    <gregtech:ore_brown_limonite_0>			.definition,
+    <gregtech:ore_calcite_0>				.definition,
+    <gregtech:ore_cassiterite_0>			.definition,
+    <gregtech:ore_certus_quartz_0>			.definition,
+    <gregtech:ore_chalcopyrite_0>			.definition,
+    <gregtech:ore_cinnabar_0>				.definition,
+    <gregtech:ore_coal_0>				.definition,
+    <gregtech:ore_cobaltite_0>				.definition,
+    <gregtech:ore_copper_0>				.definition,
+    <gregtech:ore_diamond_0>				.definition,
+    <gregtech:ore_emerald_0>				.definition,
+    <gregtech:ore_galena_0>				.definition,
+    <gregtech:ore_garnierite_0>				.definition,
+    <gregtech:ore_glauconite_0>				.definition,
+    <gregtech:ore_gold_0>				.definition,
+    <gregtech:ore_graphite_0>				.definition,
+    <gregtech:ore_green_sapphire_0>			.definition,
+    <gregtech:ore_grossular_0>				.definition,
+    <gregtech:ore_ilmenite_0>				.definition,
+    <gregtech:ore_iron_0>				.definition,
+    <gregtech:ore_lapis_0>				.definition,
+    <gregtech:ore_lazurite_0>				.definition,
+    <gregtech:ore_lead_0>				.definition,
+    <gregtech:ore_lepidolite_0>				.definition,
+    <gregtech:ore_lignite_0>				.definition,
+    <gregtech:ore_lithium_0>				.definition,
+    <gregtech:ore_magnesite_0>				.definition,
+    <gregtech:ore_magnetite_0>				.definition,
+    <gregtech:ore_malachite_0>				.definition,
+    <gregtech:ore_molybdenite_0>			.definition,
+    <gregtech:ore_monazite_0>				.definition,
+    <gregtech:ore_neodymium_0>				.definition,
+    <gregtech:ore_nether_quartz_0>			.definition,
+    <gregtech:ore_nickel_0>				.definition,
+    <gregtech:ore_oilsands_0>				.definition,
+    <gregtech:ore_olivine_0>				.definition,
+    <gregtech:ore_palladium_0>				.definition,
+    <gregtech:ore_pentlandite_0>			.definition,
+    <gregtech:ore_phosphor_0>				.definition,
+    <gregtech:ore_pitchblende_0>			.definition,
+    <gregtech:ore_platinum_0>				.definition,
+    <gregtech:ore_powellite_0>				.definition,
+    <gregtech:ore_pyrite_0>				.definition,
+    <gregtech:ore_pyrolusite_0>				.definition,
+    <gregtech:ore_pyrope_0>				.definition,
+    <gregtech:ore_quartzite_0>				.definition,
+    <gregtech:ore_redstone_0>				.definition,
+    <gregtech:ore_rock_salt_0>				.definition,
+    <gregtech:ore_ruby_0>				.definition,
+    <gregtech:ore_rutile_0>				.definition,
+    <gregtech:ore_salt_0>				.definition,
+    <gregtech:ore_sapphire_0>				.definition,
+    <gregtech:ore_scheelite_0>				.definition,
+    <gregtech:ore_silver_0>				.definition,
+    <gregtech:ore_soapstone_0>				.definition,
+    <gregtech:ore_sodalite_0>				.definition,
+    <gregtech:ore_spessartine_0>			.definition,
+    <gregtech:ore_sphalerite_0>				.definition,
+    <gregtech:ore_spodumene_0>				.definition,
+    <gregtech:ore_stibnite_0>				.definition,
+    <gregtech:ore_sulfur_0>				.definition,
+    <gregtech:ore_talc_0>				.definition,
+    <gregtech:ore_tantalite_0>				.definition,
+    <gregtech:ore_tetrahedrite_0>			.definition,
+    <gregtech:ore_thorium_0>				.definition,
+    <gregtech:ore_tin_0>				.definition,
+    <gregtech:ore_tungstate_0>				.definition,
+    <gregtech:ore_uraninite_0>				.definition,
+    <gregtech:ore_uranium_0>				.definition,
+    <gregtech:ore_vanadium_magnetite_0>			.definition,
+    <gregtech:ore_wulfenite_0>				.definition,
+    <gregtech:ore_yellow_limonite_0>			.definition,
+    <gregtech:ore_zinc_0>				.definition,
+// obtainable via microminers
+    <gregtech:ore_iridium_0>				.definition,
+    <gregtech:ore_niobium_0>				.definition,
+    <gregtech:ore_osmium_0>				.definition,
+    <gregtech:ore_tennantite_0>				.definition,
+// obtainable via omnicoins
+    <gregtech:ore_saltpeter_0>				.definition
+] as IItemDefinition[];
+
+val gtUnusedOre		= [
+    <gregtech:ore_amethyst_0>				.definition,
+    <gregtech:ore_bismuth_0>				.definition,
+    <gregtech:ore_blue_topaz_0>				.definition,
+    <gregtech:ore_bornite_0>				.definition,
+    <gregtech:ore_cassiterite_sand_0>			.definition,
+    <gregtech:ore_chalcocite_0>				.definition,
+    <gregtech:ore_chromite_0>				.definition,
+    <gregtech:ore_cobalt_0>				.definition,
+    <gregtech:ore_cooperite_0>				.definition,
+    <gregtech:ore_cuprite_0>				.definition,
+    <gregtech:ore_enargite_0>				.definition,
+    <gregtech:ore_garnet_red_0>				.definition,
+    <gregtech:ore_garnet_yellow_0>			.definition,
+    <gregtech:ore_jasper_0>				.definition,
+    <gregtech:ore_molybdenum_0>				.definition,
+    <gregtech:ore_naquadah_0>				.definition,
+    <gregtech:ore_naquadah_enriched_0>			.definition,
+    <gregtech:ore_opal_0>				.definition,
+    <gregtech:ore_phosphate_0>				.definition,
+    <gregtech:ore_tanzanite_0>				.definition,
+    <gregtech:ore_tenorite_0>				.definition,
+    <gregtech:ore_topaz_0>				.definition,
+    <gregtech:ore_uranium235_0>				.definition,
+    <gregtech:ore_vinteum_0>				.definition
+] as IItemDefinition[];
+
+// val metaDesc		= [
+//     "Insert text here"
+// ] as string[];
+
+
+for item in gtOre {
+//    mods.jei.JEI.addDescription(item.makeStack(0), metaDesc);
+
+    for meta in 1 .. 14 {
+	mods.jei.JEI.hide(item.makeStack(meta));
+    }
+}
+
+for item in gtUnusedOre {
+    for meta in 0 .. 14 {
+	mods.jei.JEI.hide(item.makeStack(meta));
+    }
+}


### PR DESCRIPTION
Changes:
1. If a GT ore isn't obtainable in Nomifactory, it and all its
   variants have been hidden in JEI.  (This removes ~300 JEI entries.)

   This needs to be double-checked.  The initial list was generated by
   taking all ores not listed in the 'config/gregtech/worldgen' and
   'scripts' dirs, along with JEI.

2. All GT ores that aren't the "meta-0" version (gravel, sand, nether,
   ...)  have been hidden in JEI.  (This removes ~1100 JEI entries.)

   This locks all JEI searches with 'r' or left-click to a single ore,
   making it easy to find all the ways an ore might be obtainable.

3. In the scripts 'Multiblocks.zs' and 'OreProcessing/DenseOres.zs',
   all references to "non-meta-0" GT ores were replaced with their
   "meta-0" counterparts.

   This makes the micro-miner and chemical reactor recipe panels show
   up when searching JEI via 'r' or left-click on an ore.

   This will probably break existing filters in worlds that used the
   specific "non-meta-0" GT ore as a filter item.  I don't have a
   world to test this in.

4. In Earlygame.zs, four non-meta-0 recipes were commented out.

   This was done for completion, to remove all "non-meta-0" GT ores.
   As far as I can see, those four lines were effectively no-ops.

5. The GT dimension config was filled out to include the other
   Advanced Rocketry planets for which GT oregen was done.

   This names the dimension IDs in the JEI GT oregen panel.  However,
   since some planets start out with no visiblity (they need to be
   researched first), it's possible this file needs to be expanded.  I
   have no world to test this in.

6. The GT moon worldgen files were cleaned up:
   a. Some files were converted from DOS line endings to Unix line endings.

      This is just a cosmetic change, to match the other GT worldgen files,
      and to make them all consistent.

   b. The weight of each vein was set to 50 instead of 0.

      This makes the JEI GT oregen panel look less confusing, as
      seeing 'weight 0' was misleading, making the player feel like no
      oregen was done.

   c. A 'dimension_filter' was added to limit 'moon' oregen to
      Advanced Rocketry planets.

      It was probably dangerous that this was missing.  I believe that
      GT was using the 'moon' files in the other dimensions, and it
      was only the 'weight: 0' that kept the vein from generating in
      the non-moon dimensions.  The 'dimension_filter' keeps that from
      being a possibility.

      Note: All Advanced Rocketry planets have the dimension name
      'planet' in Minecraft, and according to a bug report in their
      Github, this can't be changed.  So the GT oregen for 'moon' will
      be the same oregen for all Advanced Rocketry planets.  (You can
      see all the dimension names by adding the 'tellme' mod and then
      running '/tellme dump dimensions'.)