### PR TITLE
Set the languages of server launchscripts to english

### DIFF
--- a/launchscripts/launch.bat
+++ b/launchscripts/launch.bat
@@ -6,6 +6,9 @@
 :: Added java version check by t0suj4, Public Domain
 :: https://github.com/t0su4
 
+:: Set language to English 
+SET LANG=en_US
+
 :: DO NOT EDIT UNLESS YOU KNOW WHAT YOU'RE DOING
 @ECHO OFF
 SET FORGEJAR={{forgeJar}}

--- a/launchscripts/launch.sh
+++ b/launchscripts/launch.sh
@@ -8,6 +8,9 @@
 # Fixed and added java version check by t0suj4, Public Domain
 # https://github.com/t0suj4
 
+# Set language to English
+export LANG=en_US.UTF-8
+
 # DO NOT EDIT UNLESS YOU KNOW WHAT YOU'RE DOING
 FORGEJAR='{{forgeJar}}'
 JAVA_PARAMETERS='{{jvmArgs}}'


### PR DESCRIPTION
Hosting a server while using Turkish (or some other?) locales makes players unable to connect to the server. This PR fixes that.

Similar issue on Enigmatica 2 Expert's Github EnigmaticaModpacks/Enigmatica2Expert#1592

Server log while trying to connect: [2022-08-28-2.log.txt](https://github.com/Nomifactory/Nomifactory/files/9439646/2022-08-28-2.log.txt)

Client log while trying to connect: [2022-08-28-2.log.txt](https://github.com/Nomifactory/Nomifactory/files/9439651/2022-08-28-2.log.txt)

Client screenshot while trying to connect: ![](https://i.imgur.com/rCrQR7s.png)



