### PR TITLE
Rename Steel Hammer to Steel Mining Hammer

### DIFF
--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -23,7 +23,7 @@ furnace.addRecipe(<minecraft:slime_ball> * 2, <gregtech:meta_item_2:32570>, 0.0)
 <thermalfoundation:tool.hammer_stone>.displayName = "Stone Mining Hammer";
 <thermalfoundation:tool.hammer_tin>.displayName = "Tin Mining Hammer";
 <thermalfoundation:tool.hammer_copper>.displayName = "Copper Mining Hammer";
-<thermalfoundation:tool.hammer_nickel>.displayName = "Nickel Mining Hammer";
+<thermalfoundation:tool.hammer_steel>.displayName = "Steel Mining Hammer";
 <thermalfoundation:tool.hammer_platinum>.displayName = "Platinum Mining Hammer";
 <thermalfoundation:tool.hammer_bronze>.displayName = "Bronze Mining Hammer";
 <thermalfoundation:tool.hammer_iron>.displayName = "Iron Mining Hammer";


### PR DESCRIPTION
Removed rename for disabled Nickel (Mining) Hammer.
Added rename for Steel (Mining) Hammer to bring in line with other thermal hammers.

![image](https://user-images.githubusercontent.com/67842545/195487295-9295baf0-0d34-4e0d-a1a1-7e911c8eb46d.png)
