### PR TITLE
Change MV power quest to require CEF instead of input hatch

### DIFF
--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -12572,7 +12572,7 @@
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,
-              "Damage:2": 724,
+              "Damage:2": 10669,
               "OreDict:8": "",
               "id:8": "gregtech:machine"
             }


### PR DESCRIPTION
The CEF is required for MV, but the input hatch isn't
Personally I think using an MV input hatch is worse than 2 LV, as you're only using half the potential of an MV CEF (unless you're running 2 EBFs)