### PR TITLE
Cryotheum coolant unit: integer cryodust amount

### DIFF
--- a/overrides/scripts/Midgame.zs
+++ b/overrides/scripts/Midgame.zs
@@ -267,7 +267,7 @@ recipes.addShaped(<metaitem:component.capacitor> * 4, [
 	[<gregtech:meta_item_2:16062>, null, <gregtech:meta_item_2:16062>]]);
 
 assembler.recipeBuilder().inputs([<simplyjetpacks:metaitemmods:18>]).fluidInputs([<liquid:glowstone> * 4320]).outputs([<simplyjetpacks:metaitemmods:19>]).duration(2000).EUt(3000).buildAndRegister();
-assembler.recipeBuilder().inputs([<simplyjetpacks:metaitemmods:20>]).fluidInputs([<liquid:cryotheum> * 4320]).outputs([<simplyjetpacks:metaitemmods:21>]).duration(2000).EUt(8000).buildAndRegister();
+assembler.recipeBuilder().inputs([<simplyjetpacks:metaitemmods:20>]).fluidInputs([<liquid:cryotheum> * 5000]).outputs([<simplyjetpacks:metaitemmods:21>]).duration(2000).EUt(8000).buildAndRegister();
 
 
 //Gear Boxes Via Assembler


### PR DESCRIPTION
Unlike Glowstone, which gives 144 mB of the fluid per item, Cryofluid gives 250 mB per item.
This causes the amount of cryofluid required for this recipe (4320) to require a non-integer amount of cryofluid, which is annoying for automation.
This PR raises the fluid requirement from 4320 mB to 5000 mB (17.28 dusts to 20 dusts).
(It is currently possible to keep exact 4320 mB with a fluid regulator, but that requires a dedicated IV+ assembler for this one recipe, and only saves 240 cryo dust which isn't that much at ZPM)
