### PR TITLE
Add reconstructor recipe for flint (fron SiO2)

### DIFF
--- a/overrides/scripts/ActuallyAdditions.zs
+++ b/overrides/scripts/ActuallyAdditions.zs
@@ -387,5 +387,7 @@ recipes.addShaped(<actuallyadditions:block_furnace_solar>, [
 mods.jei.JEI.addDescription(<actuallyadditions:item_misc:13>, "Canola can be turned into Canola Oil via a Canola Press. This is a somewhat slow machine and requres RF to function");
 	
 	
+mods.actuallyadditions.AtomicReconstructor.addRecipe(<minecraft:flint>, <gregtech:meta_item_1:2159>, 1000);
+
 print("--- ActuallyAdditions.zs initialized ---");
 

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -779,7 +779,6 @@ recipes.addShaped(<gregtech:machine:273>, [
 
 recipes.addShapeless(<gregtech:meta_item_1:2700>, [<gregtech:meta_item_1:2033>,<minecraft:redstone>]);
 recipes.addShapeless(<minecraft:flint>, [<gregtech:meta_tool:12>, <minecraft:gravel:*>, <minecraft:gravel:*>]);
-mods.actuallyadditions.AtomicReconstructor.addRecipe(<minecraft:flint>, <gregtech:meta_item_1:2159>, 1000);
 
 furnace.addRecipe(<minecraft:iron_nugget> * 3, <gregtech:meta_item_1:2255>, 0.0);
 furnace.addRecipe(<minecraft:iron_nugget> * 2, <gregtech:meta_item_1:3255>, 0.0);

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -779,6 +779,7 @@ recipes.addShaped(<gregtech:machine:273>, [
 
 recipes.addShapeless(<gregtech:meta_item_1:2700>, [<gregtech:meta_item_1:2033>,<minecraft:redstone>]);
 recipes.addShapeless(<minecraft:flint>, [<gregtech:meta_tool:12>, <minecraft:gravel:*>, <minecraft:gravel:*>]);
+mods.actuallyadditions.AtomicReconstructor.addRecipe(<minecraft:flint>, <gregtech:meta_item_1:2159>, 1000);
 
 furnace.addRecipe(<minecraft:iron_nugget> * 3, <gregtech:meta_item_1:2255>, 0.0);
 furnace.addRecipe(<minecraft:iron_nugget> * 2, <gregtech:meta_item_1:3255>, 0.0);


### PR DESCRIPTION
Currently, the only recipe for flint is the mortar, which has durability and is therefore bad.
Flint is made of silicon dioxide, so it makes sense that messing with the atoms in silicon dioxide can turn it into flint.
