### PR TITLE
Fix inconsistent machine names

### DIFF
--- a/overrides/bansoukou/gregtech-1.12.2-1.17.1.770/assets/gregtech/lang/en_us.lang
+++ b/overrides/bansoukou/gregtech-1.12.2-1.17.1.770/assets/gregtech/lang/en_us.lang
@@ -2009,7 +2009,7 @@ gregtech.machine.chemical_reactor.ev.name=Advanced Chemical Reactor III
 gregtech.machine.compressor.lv.name=Basic Compressor
 gregtech.machine.compressor.mv.name=Advanced Compressor
 gregtech.machine.compressor.hv.name=Advanced Compressor II
-gregtech.machine.compressor.ev.name=Singularity Compressor
+gregtech.machine.compressor.ev.name=Advanced Compressor III
 
 gregtech.machine.cutter.lv.name=Basic Cutting Machine
 gregtech.machine.cutter.mv.name=Advanced Cutting Machine
@@ -2038,7 +2038,7 @@ gregtech.machine.electromagnetic_separator.ev.name=Advanced Electromagnetic Sepa
 gregtech.machine.extractor.lv.name=Basic Extractor
 gregtech.machine.extractor.mv.name=Advanced Extractor
 gregtech.machine.extractor.hv.name=Advanced Extractor II
-gregtech.machine.extractor.ev.name=Vacuum Extractor
+gregtech.machine.extractor.ev.name=Advanced Extractor III
 
 gregtech.machine.extruder.tooltip=Universal Machine for Metal Working
 
@@ -2302,7 +2302,7 @@ gregtech.machine.quantum_tank.iv.name=Black Hole-Quantum Tank III
 gregtech.machine.air_collector.lv.name=Basic Air Collector
 gregtech.machine.air_collector.mv.name=Advanced Air Collector
 gregtech.machine.air_collector.hv.name=Advanced Air Collector II
-gregtech.machine.air_collector.ev.name=Atmosphere Collector III
+gregtech.machine.air_collector.ev.name=Advanced Air Collector III
 gregtech.machine.air_collector.tooltip=Collects air from adjacent blocks at the expense of energy
 gregtech.machine.air_collector.collection_speed=Produces %,d mb of Air every %,d ticks
 gregtech.machine.air_collector.jei_description=The Air Collector collects air from adjacent blocks for a little bit of EU

--- a/overrides/bansoukou/gregtech-1.12.2-1.17.1.770/assets/gregtech/lang/ru_ru.lang
+++ b/overrides/bansoukou/gregtech-1.12.2-1.17.1.770/assets/gregtech/lang/ru_ru.lang
@@ -1927,7 +1927,7 @@ gregtech.machine.chemical_reactor.ev.name=Улучшеный химически�
 gregtech.machine.compressor.lv.name=Базовый компрессор
 gregtech.machine.compressor.mv.name=Улучшеный компрессор
 gregtech.machine.compressor.hv.name=Улучшеный компрессор II
-gregtech.machine.compressor.ev.name=Сингулярный компрессор
+gregtech.machine.compressor.ev.name=Улучшеный компрессор III
 
 gregtech.machine.cutter.lv.name=Базовая резочная машина
 gregtech.machine.cutter.mv.name=Улучшеная резочная машина
@@ -1956,7 +1956,7 @@ gregtech.machine.electromagnetic_separator.ev.name=Улучшеный элект
 gregtech.machine.extractor.lv.name=Базовый экстрактор
 gregtech.machine.extractor.mv.name=Улучшеный экстрактор
 gregtech.machine.extractor.hv.name=Улучшеный экстрактор II
-gregtech.machine.extractor.ev.name=Вакуумный экстрактор
+gregtech.machine.extractor.ev.name=Улучшеный экстрактор III
 
 gregtech.machine.extruder.tooltip=Универсальный станок для металлообработки
 
@@ -2214,7 +2214,7 @@ gregtech.machine.quantum_tank.iv.name=Квантовый резервуар на
 gregtech.machine.air_collector.lv.name=Базовый воздухосборник
 gregtech.machine.air_collector.mv.name=Улучшеный воздухосборник
 gregtech.machine.air_collector.hv.name=Улучшеный воздухосборник II
-gregtech.machine.air_collector.ev.name=Атмосферный коллектор
+gregtech.machine.air_collector.ev.name=Улучшеный воздухосборник III
 gregtech.machine.air_collector.tooltip=Собирает воздух из соседних блоков
 
 # Катушка Тесла

--- a/overrides/bansoukou/gregtech-1.12.2-1.17.1.770/assets/gregtech/lang/zh_cn.lang
+++ b/overrides/bansoukou/gregtech-1.12.2-1.17.1.770/assets/gregtech/lang/zh_cn.lang
@@ -1914,7 +1914,7 @@ gregtech.machine.chemical_reactor.ev.name=进阶化学反应釜 III
 gregtech.machine.compressor.lv.name=基础压缩机
 gregtech.machine.compressor.mv.name=进阶压缩机
 gregtech.machine.compressor.hv.name=进阶压缩机 II
-gregtech.machine.compressor.ev.name=奇点压缩机
+gregtech.machine.compressor.ev.name=进阶压缩机 III
 
 gregtech.machine.cutter.lv.name=基础板材切割机
 gregtech.machine.cutter.mv.name=进阶板材切割机
@@ -1943,7 +1943,7 @@ gregtech.machine.electromagnetic_separator.ev.name=进阶电磁选矿机 III
 gregtech.machine.extractor.lv.name=基础提取机
 gregtech.machine.extractor.mv.name=进阶提取机
 gregtech.machine.extractor.hv.name=进阶提取机 II
-gregtech.machine.extractor.ev.name=真空提取机
+gregtech.machine.extractor.ev.name=进阶提取机 III
 
 gregtech.machine.extruder.tooltip=金属处理的通用机器
 
@@ -2202,7 +2202,7 @@ gregtech.machine.quantum_tank.iv.name=黑洞量子缸 III
 gregtech.machine.air_collector.lv.name=基础空气收集器
 gregtech.machine.air_collector.mv.name=进阶空气收集器
 gregtech.machine.air_collector.hv.name=进阶空气收集器 II
-gregtech.machine.air_collector.ev.name=大气收集器 III
+gregtech.machine.air_collector.ev.name=进阶空气收集器 III
 gregtech.machine.air_collector.tooltip=从临近方块中收集空气
 
 #Tesla Coil

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -11868,7 +11868,7 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 0,
-          "desc:8": "Note: this quest accepts LV/MV/HV/EV §3Air Collectors§r.\n\nAn §3Air Collector§r will suck up air at a decent rate, provided the top side is unobstructed. The collected Air is automatically ejected into an adjacent tank via the output face.\n\nIV and LuV air collectors are not part of this quest, but for reference they exist and are called §3Atmosphere Collectors§r.\n\n",
+          "desc:8": "Note: this quest accepts LV/MV/HV/EV §3Air Collectors§r.\n\nAn §3Air Collector§r will suck up air at a decent rate, provided the top side is unobstructed. The collected Air is automatically ejected into an adjacent tank via the output face.\n\nIV and LuV air collectors are not part of this quest, but they are also available.",
           "globalshare:1": 0,
           "icon:10": {
             "Count:3": 1,


### PR DESCRIPTION
Standardize the EV machine tier names of Compressor, Extractor, Air Collector instead of the funny name normally applied.

Adjust the Air Collector quest to no longer reference Atmosphere Collectors.