### PR TITLE
Update Nightly Workflow's Action Deps and NodeJS

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,21 +7,23 @@ on:
     tags-ignore:
       - '**'
 
+# if a second commit is pushed quickly after the first, cancel the first one's build
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   nightly:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.8.0
+      - name: Checkout Ref
+        uses: actions/checkout@v4
         with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/checkout@v2
-      - run: git fetch --prune --unshallow --tags --force
+          fetch-depth: 0
 
       - name: Restore cached files
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache
         with:
           path: |
@@ -31,10 +33,10 @@ jobs:
           key: ${{ runner.os }}-bunny-${{ hashFiles('**/.cache', '**/package-lock.json', '**/manifest.json') }}
           restore-keys: ${{ runner.os }}-bunny-
 
-      - name: "Setup NodeJS v16"
-        uses: actions/setup-node@v2
+      - name: "Setup NodeJS v20"
+        uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
           check-latest: true
 
       - name: "Download NPM packages"
@@ -71,32 +73,38 @@ jobs:
         run: npx gulp makeArtifactNames
 
       - name: "Upload client artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifactNames.outputs.client }}
           path: |
             build/client/**/*
 
       - name: "Upload server artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifactNames.outputs.server }}
           path: |
             build/server/**/*
+          if-no-files-found: error
+          compression-level: 9
 
       - name: "Upload lang artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifactNames.outputs.lang }}
           path: |
             build/lang/**/*
+          if-no-files-found: error
+          compression-level: 9
 
       - name: "Upload changelog artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: changelog
           path: |
             build/shared/CHANGELOG.md
+          if-no-files-found: error
+          compression-level: 9
 
       - name: "Fire Discord webhook"
         working-directory: ./buildtools


### PR DESCRIPTION
This PR simply updates the versions of all workflows used in the nightly build to newest, using new methods for concurrency cancellation, and updating NodeJS to v20.

This should fix any deprecation messages (NodeJS is already default using v20), fixes the workflow not running due to outdated actions, and greatly improves upload speeds through the changes in Upload Artifact v4.