### PR TITLE
Add recipe to copy Space Station ID chips

### DIFF
--- a/overrides/scripts/AdvRocketry.zs
+++ b/overrides/scripts/AdvRocketry.zs
@@ -773,6 +773,13 @@ makeShaped("ar_station_id_chip",
 		C: <ore:circuitExtreme>,   // T4 Circuit
 	});
 
+// Copying Station ID chip
+recipes.addShapeless("ar_copy_station_id_chip", <advancedrocketry:spacestationchip>, [
+	<advancedrocketry:spacestationchip>.withTag({}).marked('source').reuse(), <advancedrocketry:spacestationchip>
+], function(o, inputs, c){
+	return inputs.source;
+}, null);
+
 // Warp Monitor
 recipes.remove(<advancedrocketry:warpmonitor>);
 makeShaped("ar_warp_monitor",


### PR DESCRIPTION
Players often want to make a copy of their space station ID chip to avoid losing access to the station if the original is lost. This can normally be done through the satellite builder, but that machine is disabled.

This PR adds a recipe to copy a space station ID chip by crafting it with a blank one.

I have tested this and it works.

<img width="958" height="438" alt="image" src="https://github.com/user-attachments/assets/78f5723b-c6af-4992-8959-dd2a878cd10f" />
